### PR TITLE
Add portal V1: dashboard, quote history, API layer, and error handling

### DIFF
--- a/components/portal/PortalShell.tsx
+++ b/components/portal/PortalShell.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode } from "react";
+import { signOut, useSession } from "next-auth/react";
+import Head from "next/head";
+import Link from "next/link";
+import { useInactivityTimeout } from "../../lib/portal/useInactivityTimeout";
+
+interface PortalShellProps {
+  title?: string;
+  children: ReactNode;
+}
+
+export default function PortalShell({
+  title = "Partner Portal",
+  children,
+}: PortalShellProps) {
+  const { data: session, status } = useSession();
+  useInactivityTimeout();
+
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen bg-gi-fog flex items-center justify-center">
+        <div className="animate-pulse text-gi-navy/50 text-sm">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{title} | Green Irony</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+
+      <div className="min-h-screen bg-gi-fog">
+        <header className="bg-white border-b border-gi-line">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Link href="/portal/">
+                <img
+                  src="/logos/green-irony/Green-Irony-Logo.svg"
+                  alt="Green Irony"
+                  className="h-8"
+                />
+              </Link>
+              <span className="inline-flex items-center rounded-md bg-gi-green/10 px-2 py-1 text-xs font-medium text-gi-green ring-1 ring-inset ring-gi-green/20">
+                Portal
+              </span>
+            </div>
+
+            <div className="flex items-center gap-4">
+              {session?.user?.image && (
+                <img
+                  src={session.user.image}
+                  alt=""
+                  className="h-8 w-8 rounded-full"
+                  referrerPolicy="no-referrer"
+                />
+              )}
+              <span className="hidden sm:block text-sm text-gi-navy">
+                {session?.user?.name}
+              </span>
+              <button
+                onClick={() => signOut({ callbackUrl: "/" })}
+                className="text-sm text-gi-navy/60 hover:text-gi-navy transition"
+              >
+                Sign out
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {children}
+      </div>
+    </>
+  );
+}

--- a/components/portal/QuoteResults.tsx
+++ b/components/portal/QuoteResults.tsx
@@ -1,0 +1,172 @@
+import Link from "next/link";
+import type { QuoteResponse } from "../../lib/portal/types";
+
+const CONFIDENCE_STYLES: Record<
+  QuoteResponse["confidence_level"],
+  string
+> = {
+  High: "bg-green-50 text-gi-green ring-gi-green/20",
+  Medium: "bg-amber-50 text-amber-600 ring-amber-600/20",
+  Low: "bg-red-50 text-red-600 ring-red-600/20",
+};
+
+function ConfidenceBadge({
+  level,
+}: {
+  level: QuoteResponse["confidence_level"];
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${CONFIDENCE_STYLES[level]}`}
+    >
+      {level}
+    </span>
+  );
+}
+
+function formatPrice(low: number, high: number) {
+  const fmt = (n: number) =>
+    n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  return `${fmt(low)} – ${fmt(high)}`;
+}
+
+interface QuoteResultsProps {
+  quote: QuoteResponse;
+  onRefine?: () => void;
+}
+
+export default function QuoteResults({ quote, onRefine }: QuoteResultsProps) {
+  const scopeParagraphs = quote.scope_summary.split("\n").filter(Boolean);
+
+  return (
+    <div className="space-y-6">
+      {/* Quote Summary */}
+      <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-6 sm:p-8">
+        <h2 className="text-lg font-semibold text-gi-navy mb-5">
+          Quote Summary
+        </h2>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <div>
+            <p className="text-xs text-gi-navy/50 mb-1">Estimated Price Range</p>
+            <p className="text-lg font-semibold text-gi-navy">
+              {formatPrice(quote.price_low, quote.price_high)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gi-navy/50 mb-1">Offering Tier</p>
+            <p className="text-lg font-semibold text-gi-navy">
+              {quote.offering_tier}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gi-navy/50 mb-1">Timeline</p>
+            <p className="text-lg font-semibold text-gi-navy">
+              ~{quote.timeline_weeks} weeks
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gi-navy/50 mb-1">Confidence</p>
+            <div className="mt-1">
+              <ConfidenceBadge level={quote.confidence_level} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Scope Summary */}
+      <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-6 sm:p-8">
+        <h2 className="text-lg font-semibold text-gi-navy mb-4">
+          Scope Summary
+        </h2>
+
+        <div className="space-y-3 text-sm text-gi-navy/80">
+          {scopeParagraphs.map((para, i) => (
+            <p key={i}>{para}</p>
+          ))}
+        </div>
+
+        <div className="mt-6 space-y-5">
+          {[
+            { heading: "Integration Use Cases", items: quote.key_use_cases },
+            { heading: "Assumptions", items: quote.assumptions },
+            { heading: "Not Included", items: quote.not_included },
+          ].map((section) => (
+            <div key={section.heading}>
+              <h3 className="text-sm font-semibold text-gi-navy mb-2">
+                {section.heading}
+              </h3>
+              <ul className="space-y-1.5">
+                {section.items.map((item, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm text-gi-navy/70"
+                  >
+                    <span className="mt-[5px] h-2 w-2 shrink-0 rounded-full bg-gi-green" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <div>
+            <h3 className="text-sm font-semibold text-gi-navy mb-2">
+              Recommended Next Steps
+            </h3>
+            <p className="text-sm text-gi-navy/70">
+              {quote.recommended_next_steps}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Additional Services Notice */}
+      {quote.additional_services && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+          <p className="font-semibold mb-1">
+            Additional Services Identified
+          </p>
+          <p>{quote.additional_services}</p>
+          <p className="mt-2 text-amber-700">
+            Contact your Green Irony AE to discuss these services.
+          </p>
+        </div>
+      )}
+
+      {/* Call to Action */}
+      <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-6 sm:p-8">
+        <div className="flex flex-wrap gap-3">
+          <Link href="/contact/" className="btn-primary">
+            Schedule a call with Green Irony
+          </Link>
+          <button
+            type="button"
+            className="btn-secondary opacity-50 cursor-not-allowed"
+            disabled
+            title="Coming soon"
+          >
+            Download this quote
+          </button>
+          {onRefine && (
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={onRefine}
+            >
+              Refine this quote
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Disclaimer */}
+      <p className="text-xs text-gi-navy/40 text-center px-4">
+        This quote was generated by Green Irony&apos;s AI-powered quoting
+        engine. For a detailed, customer-ready SOW, connect with your Green
+        Irony AE.
+      </p>
+    </div>
+  );
+}
+
+export { ConfidenceBadge, formatPrice, CONFIDENCE_STYLES };

--- a/lib/portal/mockData.ts
+++ b/lib/portal/mockData.ts
@@ -1,0 +1,146 @@
+import type { QuoteResponse, QuoteListItem } from "./types";
+
+export const MOCK_QUOTES: QuoteResponse[] = [
+  {
+    quote_id: "q-001",
+    customer_name: "Acme Corp",
+    price_low: 18000,
+    price_high: 25000,
+    offering_tier: "Growth Integration Package",
+    timeline_weeks: "4-5",
+    confidence_level: "High",
+    scope_summary:
+      "This engagement covers a bidirectional integration between Salesforce and your ERP system, enabling real-time data synchronization across sales, order management, and customer service workflows. The solution will be built on MuleSoft's Anypoint Platform using API-led connectivity principles.\n\nThe integration scope includes automated order-to-cash flows, real-time inventory availability checks from within Salesforce, and bidirectional contact/account synchronization. Error handling, retry logic, and operational dashboards are included in the base package.",
+    key_use_cases: [
+      "Salesforce <> ERP bidirectional account & contact sync",
+      "Real-time order status updates pushed to Salesforce",
+      "Inventory availability check (Salesforce to ERP, on-demand)",
+      "Automated case creation from ERP service events",
+    ],
+    assumptions: [
+      "Client has an active MuleSoft Anypoint Platform license (CloudHub 2.0 or Runtime Fabric)",
+      "ERP system exposes RESTful or SOAP APIs for the required data objects",
+      "Salesforce edition supports API access (Enterprise or above)",
+      "Green Irony will be granted sandbox access within the first week",
+    ],
+    not_included: [
+      "Custom ERP development or modifications to ERP-side APIs",
+      "MuleSoft or Salesforce license procurement",
+      "Historical data migration or bulk data cleansing",
+      "End-user training beyond admin-level knowledge transfer",
+    ],
+    recommended_next_steps:
+      "Schedule a discovery call with a Green Irony Solutions Architect to review your integration requirements in detail. Gather and share ERP API documentation (endpoints, auth, schemas). Identify key stakeholders for a 60-minute requirements workshop.",
+    created_at: "2026-02-15T14:30:00Z",
+  },
+  {
+    quote_id: "q-002",
+    customer_name: "TechVentures Inc",
+    price_low: 35000,
+    price_high: 50000,
+    offering_tier: "Enterprise Integration Suite",
+    timeline_weeks: "8-10",
+    confidence_level: "Medium",
+    scope_summary:
+      "A multi-system integration connecting Salesforce, SAP S/4HANA, and a custom data warehouse. This project involves building an API-led architecture with experience, process, and system API layers to support both real-time and batch data flows.\n\nThe scope includes customer master data management across all three systems, automated invoice reconciliation, and a self-service API portal for internal development teams. Given the complexity of the SAP landscape, a phased rollout is recommended.",
+    key_use_cases: [
+      "Customer master data sync across Salesforce, SAP, and data warehouse",
+      "Automated invoice reconciliation between SAP and Salesforce CPQ",
+      "Self-service API portal for internal dev teams",
+      "Batch nightly sync for financial reporting data",
+    ],
+    assumptions: [
+      "SAP S/4HANA is accessible via OData or RFC interfaces",
+      "MuleSoft Anypoint Platform with API Manager is licensed",
+      "Client will provide a dedicated integration architect for the project",
+      "Data warehouse has a REST or JDBC-compatible ingestion layer",
+    ],
+    not_included: [
+      "SAP ABAP development or custom BAPIs",
+      "Data warehouse schema design or ETL pipeline development",
+      "Salesforce CPQ configuration or customization",
+      "Performance testing beyond standard integration load tests",
+    ],
+    recommended_next_steps:
+      "Engage Green Irony for a 2-week discovery sprint to map out data flows and integration patterns. Share SAP system landscape documentation and Salesforce org details for initial assessment.",
+    additional_services:
+      "This engagement may benefit from Salesforce CPQ configuration and SAP consulting services, which fall outside MuleSoft integration scope. Green Irony can coordinate with specialized partners for these workstreams.",
+    created_at: "2026-02-10T09:15:00Z",
+  },
+  {
+    quote_id: "q-003",
+    customer_name: "Retail Solutions Group",
+    price_low: 12000,
+    price_high: 18000,
+    offering_tier: "Starter Integration Package",
+    timeline_weeks: "3-4",
+    confidence_level: "High",
+    scope_summary:
+      "A focused integration between Shopify and Salesforce Service Cloud to unify e-commerce order data with customer service workflows. Orders placed in Shopify will be synced to Salesforce in near-real-time, enabling service agents to view complete order history.\n\nThe integration uses MuleSoft's pre-built Shopify connector and includes webhook-based event processing for order creation, updates, and fulfillment status changes.",
+    key_use_cases: [
+      "Shopify order sync to Salesforce Service Cloud (near-real-time)",
+      "Customer profile unification across Shopify and Salesforce",
+      "Fulfillment status updates surfaced in Salesforce cases",
+      "Webhook-based event processing for order lifecycle events",
+    ],
+    assumptions: [
+      "Shopify Plus plan with API access enabled",
+      "Salesforce Service Cloud with API access (Enterprise edition or above)",
+      "MuleSoft CloudHub 2.0 license with at least 0.2 vCores",
+      "Standard Shopify data model (no heavily customized checkout)",
+    ],
+    not_included: [
+      "Shopify theme or checkout customization",
+      "Salesforce Service Cloud configuration or case routing rules",
+      "Historical order migration from legacy systems",
+      "Custom reporting dashboards beyond MuleSoft operational monitoring",
+    ],
+    recommended_next_steps:
+      "Share Shopify store admin access and Salesforce sandbox credentials to begin connector configuration. A 30-minute kickoff call will align on field mappings and data transformation requirements.",
+    created_at: "2026-02-05T16:45:00Z",
+  },
+  {
+    quote_id: "q-004",
+    customer_name: "HealthFirst Partners",
+    price_low: 55000,
+    price_high: 80000,
+    offering_tier: "Enterprise Integration Suite",
+    timeline_weeks: "12-16",
+    confidence_level: "Low",
+    scope_summary:
+      "A complex healthcare integration involving HL7 FHIR-compliant data exchange between an EHR system, Salesforce Health Cloud, and multiple third-party payer systems. This project requires HIPAA-compliant data handling, encryption at rest and in transit, and comprehensive audit logging.\n\nDue to the regulatory requirements and the number of external system interfaces, a detailed discovery phase is essential before finalizing scope. The estimate range reflects uncertainty around payer system API maturity and data standardization requirements.",
+    key_use_cases: [
+      "HL7 FHIR-based patient data exchange between EHR and Salesforce Health Cloud",
+      "Payer eligibility verification in real-time",
+      "Claims status sync across multiple payer systems",
+      "HIPAA-compliant audit logging and data governance",
+    ],
+    assumptions: [
+      "EHR system supports HL7 FHIR R4 APIs",
+      "Payer systems have documented API interfaces (varying maturity expected)",
+      "Client has a HIPAA compliance framework in place",
+      "MuleSoft Anypoint Platform with dedicated VPC for data isolation",
+    ],
+    not_included: [
+      "EHR system configuration or customization",
+      "HIPAA compliance consulting or policy development",
+      "Salesforce Health Cloud implementation or configuration",
+      "Payer contract negotiations or onboarding",
+    ],
+    recommended_next_steps:
+      "A 3-4 week discovery engagement is strongly recommended before committing to the full build. This will clarify payer API capabilities, data mapping requirements, and compliance review needs.",
+    additional_services:
+      "This project will likely require Salesforce Health Cloud implementation services and HIPAA compliance consulting. These are outside the scope of MuleSoft integration work and should be planned as parallel workstreams.",
+    created_at: "2026-01-28T11:00:00Z",
+  },
+];
+
+export const MOCK_QUOTE_LIST: QuoteListItem[] = MOCK_QUOTES.map((q) => ({
+  quote_id: q.quote_id,
+  customer_name: q.customer_name,
+  price_low: q.price_low,
+  price_high: q.price_high,
+  confidence_level: q.confidence_level,
+  offering_tier: q.offering_tier,
+  created_at: q.created_at,
+}));

--- a/lib/portal/quoteService.ts
+++ b/lib/portal/quoteService.ts
@@ -1,0 +1,90 @@
+import type {
+  ApiResult,
+  GenerateQuoteInput,
+  QuoteListItem,
+  QuoteResponse,
+} from "./types";
+import { MOCK_QUOTES, MOCK_QUOTE_LIST } from "./mockData";
+
+const USE_MOCK = !process.env.NEXT_PUBLIC_PORTAL_API_URL;
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function generateQuote(
+  input: GenerateQuoteInput,
+  _userEmail: string,
+): Promise<ApiResult<QuoteResponse>> {
+  if (USE_MOCK) {
+    await delay(2500);
+    // Return a new quote based on the first mock, with a fresh ID and timestamp
+    const mock: QuoteResponse = {
+      ...MOCK_QUOTES[0],
+      quote_id: `q-${Date.now()}`,
+      created_at: new Date().toISOString(),
+    };
+    return { ok: true, data: mock };
+  }
+
+  try {
+    const formData = new FormData();
+    formData.append("deal_context", input.deal_context);
+    if (input.file) formData.append("file", input.file);
+
+    const res = await fetch("/api/portal/quote", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, message: body.message || "Failed to generate quote" };
+    }
+
+    const data: QuoteResponse = await res.json();
+    return { ok: true, data };
+  } catch {
+    return { ok: false, message: "Network error — please try again" };
+  }
+}
+
+export async function listQuotes(): Promise<ApiResult<QuoteListItem[]>> {
+  if (USE_MOCK) {
+    return { ok: true, data: MOCK_QUOTE_LIST };
+  }
+
+  try {
+    const res = await fetch("/api/portal/quotes");
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, message: body.message || "Failed to load quotes" };
+    }
+    const data: QuoteListItem[] = await res.json();
+    return { ok: true, data };
+  } catch {
+    return { ok: false, message: "Network error — please try again" };
+  }
+}
+
+export async function getQuote(
+  id: string,
+): Promise<ApiResult<QuoteResponse>> {
+  if (USE_MOCK) {
+    const quote = MOCK_QUOTES.find((q) => q.quote_id === id);
+    if (!quote) return { ok: false, message: "Quote not found" };
+    return { ok: true, data: quote };
+  }
+
+  try {
+    const res = await fetch(`/api/portal/quotes/${encodeURIComponent(id)}`);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, message: body.message || "Failed to load quote" };
+    }
+    const data: QuoteResponse = await res.json();
+    return { ok: true, data };
+  } catch {
+    return { ok: false, message: "Network error — please try again" };
+  }
+}

--- a/lib/portal/types.ts
+++ b/lib/portal/types.ts
@@ -1,0 +1,37 @@
+export interface QuoteResponse {
+  quote_id: string;
+  customer_name: string;
+  price_low: number;
+  price_high: number;
+  offering_tier: string;
+  timeline_weeks: string;
+  confidence_level: "High" | "Medium" | "Low";
+  scope_summary: string;
+  key_use_cases: string[];
+  assumptions: string[];
+  not_included: string[];
+  recommended_next_steps: string;
+  additional_services?: string;
+  created_at: string;
+}
+
+export interface QuoteListItem {
+  quote_id: string;
+  customer_name: string;
+  price_low: number;
+  price_high: number;
+  confidence_level: "High" | "Medium" | "Low";
+  offering_tier: string;
+  created_at: string;
+}
+
+export interface GenerateQuoteInput {
+  deal_context: string;
+  file?: File;
+}
+
+export interface ApiResult<T> {
+  ok: boolean;
+  data?: T;
+  message?: string;
+}

--- a/lib/portal/useInactivityTimeout.ts
+++ b/lib/portal/useInactivityTimeout.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { signOut } from "next-auth/react";
+
+export function useInactivityTimeout(timeoutMs = 30 * 60 * 1000): void {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    function resetTimer() {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        signOut({ callbackUrl: "/portal/sign-in/" });
+      }, timeoutMs);
+    }
+
+    const events: (keyof WindowEventMap)[] = [
+      "mousemove",
+      "keydown",
+      "touchstart",
+      "scroll",
+    ];
+
+    events.forEach((event) => window.addEventListener(event, resetTimer));
+    resetTimer();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      events.forEach((event) => window.removeEventListener(event, resetTimer));
+    };
+  }, [timeoutMs]);
+}

--- a/pages/api/portal/quote.ts
+++ b/pages/api/portal/quote.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getToken } from "next-auth/jwt";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const token = await getToken({ req });
+  if (!token) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  // TODO: Forward to MuleSoft POST /api/v1/quote when backend is ready
+  return res.status(501).json({ message: "Backend not connected" });
+}

--- a/pages/api/portal/quotes.ts
+++ b/pages/api/portal/quotes.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getToken } from "next-auth/jwt";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const token = await getToken({ req });
+  if (!token) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  // TODO: Forward to MuleSoft GET /api/v1/quotes when backend is ready
+  return res.status(501).json({ message: "Backend not connected" });
+}

--- a/pages/api/portal/quotes/[id].ts
+++ b/pages/api/portal/quotes/[id].ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getToken } from "next-auth/jwt";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const token = await getToken({ req });
+  if (!token) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  // const { id } = req.query;
+  // TODO: Forward to MuleSoft GET /api/v1/quote/{id} when backend is ready
+  return res.status(501).json({ message: "Backend not connected" });
+}

--- a/pages/portal/index.tsx
+++ b/pages/portal/index.tsx
@@ -1,127 +1,171 @@
-import { signOut, useSession } from "next-auth/react";
-import Head from "next/head";
-
-const PLACEHOLDER_CARDS = [
-  {
-    title: "Projects",
-    description: "View and manage joint implementation projects",
-    icon: (
-      <svg className="h-6 w-6 text-gi-green" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
-      </svg>
-    ),
-  },
-  {
-    title: "Documents",
-    description: "Access shared resources and documentation",
-    icon: (
-      <svg className="h-6 w-6 text-gi-green" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-      </svg>
-    ),
-  },
-  {
-    title: "Support",
-    description: "Get help and submit support requests",
-    icon: (
-      <svg className="h-6 w-6 text-gi-green" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
-      </svg>
-    ),
-  },
-];
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { motion as m, useReducedMotion } from "framer-motion";
+import PortalShell from "../../components/portal/PortalShell";
+import {
+  ConfidenceBadge,
+  formatPrice,
+} from "../../components/portal/QuoteResults";
+import { listQuotes } from "../../lib/portal/quoteService";
+import type { QuoteListItem } from "../../lib/portal/types";
 
 export default function PortalDashboard() {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
+  const router = useRouter();
+  const prefersReduced = useReducedMotion();
+  const reduced = !!prefersReduced;
 
-  if (status === "loading") {
-    return (
-      <div className="min-h-screen bg-gi-fog flex items-center justify-center">
-        <div className="animate-pulse text-gi-navy/50 text-sm">Loading...</div>
-      </div>
-    );
-  }
+  const [quotes, setQuotes] = useState<QuoteListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
 
-  const firstName = session?.user?.name?.split(" ")[0] || "there";
+  const firstName = session?.user?.name?.split(" ")[0] ?? "there";
+
+  useEffect(() => {
+    listQuotes().then((result) => {
+      if (result.ok && result.data) {
+        setQuotes(result.data);
+      } else {
+        setError(result.message ?? "Failed to load quotes");
+      }
+      setLoading(false);
+    });
+  }, []);
+
+  const fade = {
+    initial: reduced ? { opacity: 0 } : { opacity: 0, y: 16 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: reduced ? 0.15 : 0.35 },
+  };
 
   return (
-    <>
-      <Head>
-        <title>Partner Portal | Green Irony</title>
-        <meta name="robots" content="noindex, nofollow" />
-      </Head>
-
-      <div className="min-h-screen bg-gi-fog">
-        {/* Portal header */}
-        <header className="bg-white border-b border-gi-line">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <img
-                src="/logos/green-irony/Green-Irony-Logo.svg"
-                alt="Green Irony"
-                className="h-8"
-              />
-              <span className="inline-flex items-center rounded-md bg-gi-green/10 px-2 py-1 text-xs font-medium text-gi-green ring-1 ring-inset ring-gi-green/20">
-                Portal
-              </span>
+    <PortalShell>
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-10">
+        <m.div {...fade}>
+          {/* Header row */}
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+            <div>
+              <h1 className="text-2xl font-semibold text-gi-navy">
+                Welcome back, {firstName}
+              </h1>
+              <p className="text-sm text-gi-navy/60 mt-1">
+                Generate and manage integration quotes for your deals.
+              </p>
             </div>
-
-            <div className="flex items-center gap-4">
-              {session?.user?.image && (
-                <img
-                  src={session.user.image}
-                  alt=""
-                  className="h-8 w-8 rounded-full"
-                  referrerPolicy="no-referrer"
-                />
-              )}
-              <span className="hidden sm:block text-sm text-gi-navy">
-                {session?.user?.name}
-              </span>
-              <button
-                onClick={() => signOut({ callbackUrl: "/" })}
-                className="text-sm text-gi-navy/60 hover:text-gi-navy transition"
-              >
-                Sign out
-              </button>
-            </div>
-          </div>
-        </header>
-
-        {/* Dashboard content */}
-        <main className="max-w-6xl mx-auto px-4 sm:px-6 py-10">
-          <div className="mb-8">
-            <h1 className="text-2xl font-semibold text-gi-navy">
-              Welcome, {firstName}
-            </h1>
-            <p className="text-sm text-gi-navy/60 mt-1">
-              {session?.user?.email}
-            </p>
+            <Link href="/portal/quotes/new/" className="btn-primary shrink-0">
+              New Quote
+            </Link>
           </div>
 
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {PLACEHOLDER_CARDS.map((card) => (
-              <div
-                key={card.title}
-                className="bg-white rounded-xl border border-gi-line p-6 shadow-sm"
-              >
-                <div className="flex items-center gap-3 mb-3">
-                  {card.icon}
-                  <h2 className="text-lg font-semibold text-gi-navy">
-                    {card.title}
-                  </h2>
+          {/* Quote list */}
+          <div className="rounded-2xl border border-gi-line bg-white shadow-gi">
+            <div className="px-6 py-4 border-b border-gi-line">
+              <h2 className="text-lg font-semibold text-gi-navy">
+                Quote History
+              </h2>
+            </div>
+
+            {loading && (
+              <div className="px-6 py-16 text-center">
+                <div className="animate-pulse text-gi-navy/50 text-sm">
+                  Loading quotes...
                 </div>
-                <p className="text-sm text-gi-navy/60 mb-4">
-                  {card.description}
-                </p>
-                <span className="inline-flex items-center rounded-full bg-gi-fog px-3 py-1 text-xs font-medium text-gi-navy/40">
-                  Coming soon
-                </span>
               </div>
-            ))}
+            )}
+
+            {!loading && error && (
+              <div className="px-6 py-16 text-center">
+                <p className="text-sm text-red-600">{error}</p>
+              </div>
+            )}
+
+            {!loading && !error && quotes.length === 0 && (
+              <div className="px-6 py-16 text-center">
+                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gi-fog">
+                  <svg
+                    className="h-6 w-6 text-gi-navy/30"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                    />
+                  </svg>
+                </div>
+                <p className="text-sm font-medium text-gi-navy mb-1">
+                  No quotes yet
+                </p>
+                <p className="text-sm text-gi-navy/50 mb-4">
+                  Generate your first quote to get started.
+                </p>
+                <Link href="/portal/quotes/new/" className="btn-primary">
+                  Generate your first quote
+                </Link>
+              </div>
+            )}
+
+            {!loading && !error && quotes.length > 0 && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gi-line text-left text-xs text-gi-navy/50">
+                      <th className="px-6 py-3 font-medium">Customer</th>
+                      <th className="px-6 py-3 font-medium">Price Range</th>
+                      <th className="px-6 py-3 font-medium">Confidence</th>
+                      <th className="px-6 py-3 font-medium hidden sm:table-cell">
+                        Offering
+                      </th>
+                      <th className="px-6 py-3 font-medium hidden md:table-cell">
+                        Date
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {quotes.map((q) => (
+                      <tr
+                        key={q.quote_id}
+                        onClick={() =>
+                          router.push(`/portal/quotes/${q.quote_id}/`)
+                        }
+                        className="border-b border-gi-line hover:bg-gi-fog/50 transition-colors cursor-pointer"
+                      >
+                        <td className="px-6 py-4 font-medium text-gi-navy">
+                          {q.customer_name}
+                        </td>
+                        <td className="px-6 py-4 text-gi-navy/70">
+                          {formatPrice(q.price_low, q.price_high)}
+                        </td>
+                        <td className="px-6 py-4">
+                          <ConfidenceBadge level={q.confidence_level} />
+                        </td>
+                        <td className="px-6 py-4 text-gi-navy/70 hidden sm:table-cell">
+                          {q.offering_tier}
+                        </td>
+                        <td className="px-6 py-4 text-gi-navy/50 hidden md:table-cell">
+                          {new Date(q.created_at).toLocaleDateString(
+                            "en-US",
+                            {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            },
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
-        </main>
-      </div>
-    </>
+        </m.div>
+      </main>
+    </PortalShell>
   );
 }

--- a/pages/portal/quotes/[id].tsx
+++ b/pages/portal/quotes/[id].tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { motion as m, useReducedMotion } from "framer-motion";
+import PortalShell from "../../../components/portal/PortalShell";
+import QuoteResults from "../../../components/portal/QuoteResults";
+import { getQuote } from "../../../lib/portal/quoteService";
+import type { QuoteResponse } from "../../../lib/portal/types";
+
+export default function QuoteDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const prefersReduced = useReducedMotion();
+  const reduced = !!prefersReduced;
+
+  const [quote, setQuote] = useState<QuoteResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!id || typeof id !== "string") return;
+
+    setLoading(true);
+    getQuote(id).then((result) => {
+      if (result.ok && result.data) {
+        setQuote(result.data);
+      } else {
+        setError(result.message ?? "Quote not found");
+      }
+      setLoading(false);
+    });
+  }, [id]);
+
+  const fade = {
+    initial: reduced ? { opacity: 0 } : { opacity: 0, y: 16 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: reduced ? 0.15 : 0.35 },
+  };
+
+  return (
+    <PortalShell title="Quote Details">
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        <Link
+          href="/portal/"
+          className="inline-flex items-center gap-1 text-sm text-gi-navy/60 hover:text-gi-navy transition mb-6"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 19.5 8.25 12l7.5-7.5"
+            />
+          </svg>
+          Back to dashboard
+        </Link>
+
+        {loading && (
+          <div className="flex items-center justify-center py-32">
+            <div className="animate-pulse text-gi-navy/50 text-sm">
+              Loading quote...
+            </div>
+          </div>
+        )}
+
+        {!loading && error && (
+          <m.div
+            {...fade}
+            className="flex flex-col items-center justify-center py-32"
+          >
+            <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-8 max-w-md text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
+                <svg
+                  className="h-6 w-6 text-red-500"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-lg font-semibold text-gi-navy mb-2">
+                Quote not found
+              </h2>
+              <p className="text-sm text-gi-navy/60 mb-6">{error}</p>
+              <Link href="/portal/" className="btn-primary">
+                Back to dashboard
+              </Link>
+            </div>
+          </m.div>
+        )}
+
+        {!loading && quote && (
+          <m.div {...fade}>
+            <h1 className="text-2xl font-semibold text-gi-navy mb-1">
+              {quote.customer_name}
+            </h1>
+            <p className="text-sm text-gi-navy/50 mb-6">
+              Generated{" "}
+              {new Date(quote.created_at).toLocaleDateString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </p>
+            <QuoteResults quote={quote} />
+          </m.div>
+        )}
+      </main>
+    </PortalShell>
+  );
+}

--- a/pages/portal/quotes/new.tsx
+++ b/pages/portal/quotes/new.tsx
@@ -1,0 +1,320 @@
+import { useState, useRef, type DragEvent } from "react";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { motion as m, AnimatePresence, useReducedMotion } from "framer-motion";
+import PortalShell from "../../../components/portal/PortalShell";
+import QuoteResults from "../../../components/portal/QuoteResults";
+import { generateQuote } from "../../../lib/portal/quoteService";
+import type { QuoteResponse } from "../../../lib/portal/types";
+
+const ALLOWED_MIME = [
+  "text/plain",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+const ALLOWED_EXT = [".txt", ".pdf", ".docx"];
+
+function isFileAllowed(file: File) {
+  const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+  return ALLOWED_MIME.includes(file.type) || ALLOWED_EXT.includes(ext);
+}
+
+function BouncingDots({ reduced }: { reduced: boolean }) {
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      {[0, 1, 2].map((i) => (
+        <m.span
+          key={i}
+          className="block h-2.5 w-2.5 rounded-full bg-gi-green"
+          animate={reduced ? {} : { y: [0, -8, 0] }}
+          transition={{
+            duration: 0.6,
+            repeat: Infinity,
+            delay: i * 0.15,
+            ease: "easeInOut",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+type ViewState = "input" | "generating" | "results" | "error";
+
+export default function NewQuotePage() {
+  const { data: session } = useSession();
+  const prefersReduced = useReducedMotion();
+  const reduced = !!prefersReduced;
+
+  const [view, setView] = useState<ViewState>("input");
+  const [dealContext, setDealContext] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [quote, setQuote] = useState<QuoteResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const canGenerate = dealContext.trim().length > 0 || file !== null;
+
+  async function handleGenerate() {
+    setView("generating");
+    const result = await generateQuote(
+      { deal_context: dealContext, file: file ?? undefined },
+      session?.user?.email ?? "",
+    );
+    if (result.ok && result.data) {
+      setQuote(result.data);
+      setView("results");
+    } else {
+      setErrorMessage(result.message ?? "Something went wrong");
+      setView("error");
+    }
+  }
+
+  function handleRefine() {
+    setView("input");
+  }
+
+  function handleTryAgain() {
+    setErrorMessage("");
+    setView("input");
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    setDragOver(true);
+  }
+  function handleDragLeave(e: DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+  }
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    const dropped = e.dataTransfer.files[0];
+    if (dropped && isFileAllowed(dropped)) setFile(dropped);
+  }
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0];
+    if (selected && isFileAllowed(selected)) setFile(selected);
+  }
+
+  const fade = (delay = 0) => ({
+    initial: reduced ? { opacity: 0 } : { opacity: 0, y: 16 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: reduced ? 0 : -8 },
+    transition: { duration: reduced ? 0.15 : 0.35, delay },
+  });
+
+  return (
+    <PortalShell title="New Quote">
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        {/* Back link */}
+        <Link
+          href="/portal/"
+          className="inline-flex items-center gap-1 text-sm text-gi-navy/60 hover:text-gi-navy transition mb-6"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 19.5 8.25 12l7.5-7.5"
+            />
+          </svg>
+          Back to dashboard
+        </Link>
+
+        <AnimatePresence mode="wait">
+          {/* INPUT */}
+          {view === "input" && (
+            <m.div key="input" {...fade()}>
+              <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-6 sm:p-8">
+                <h1 className="text-2xl font-semibold text-gi-navy">
+                  Quote Generator
+                </h1>
+                <p className="text-sm text-gi-navy/60 mt-1 mb-6">
+                  Describe the deal context — technology stack, integration
+                  requirements, timeline, and any other relevant details.
+                </p>
+
+                <textarea
+                  rows={6}
+                  value={dealContext}
+                  onChange={(e) => setDealContext(e.target.value)}
+                  placeholder="e.g. Our client needs a Salesforce ↔ NetSuite integration for order-to-cash. They have MuleSoft Anypoint Platform and want real-time sync. ~200 orders/day, 3 Salesforce orgs..."
+                  className="w-full rounded-xl border border-gi-line bg-gi-fog/50 px-4 py-3 text-sm text-gi-navy placeholder:text-gi-navy/40 focus:outline-none focus:ring-2 focus:ring-gi-green focus:border-transparent resize-y"
+                />
+
+                <div
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                  onClick={() => fileInputRef.current?.click()}
+                  className={`mt-4 flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-4 py-6 text-center cursor-pointer transition-colors ${
+                    dragOver
+                      ? "border-gi-green bg-gi-green/5"
+                      : "border-gi-line hover:border-gi-navy/30"
+                  }`}
+                >
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".txt,.pdf,.docx"
+                    onChange={handleFileChange}
+                    className="hidden"
+                  />
+
+                  {file ? (
+                    <div className="flex items-center gap-2 text-sm text-gi-navy">
+                      <svg
+                        className="h-5 w-5 text-gi-green"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                        />
+                      </svg>
+                      <span className="font-medium">{file.name}</span>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFile(null);
+                          if (fileInputRef.current)
+                            fileInputRef.current.value = "";
+                        }}
+                        className="ml-1 text-gi-navy/40 hover:text-gi-pink transition"
+                        aria-label="Remove file"
+                      >
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth={2}
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M6 18 18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <svg
+                        className="h-8 w-8 text-gi-navy/30"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+                        />
+                      </svg>
+                      <p className="text-sm text-gi-navy/50">
+                        Have a call recording or transcript? Drop it here for a
+                        more accurate quote.
+                      </p>
+                      <p className="text-xs text-gi-navy/30">
+                        .txt, .pdf, or .docx
+                      </p>
+                    </>
+                  )}
+                </div>
+
+                <button
+                  onClick={handleGenerate}
+                  disabled={!canGenerate}
+                  className="btn-primary mt-6 w-full disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Generate Quote
+                </button>
+              </div>
+            </m.div>
+          )}
+
+          {/* GENERATING */}
+          {view === "generating" && (
+            <m.div
+              key="generating"
+              {...fade()}
+              className="flex flex-col items-center justify-center py-32"
+            >
+              <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-10 flex flex-col items-center gap-5">
+                <BouncingDots reduced={reduced} />
+                <p className="text-sm text-gi-navy/60">
+                  Analyzing your deal context...
+                </p>
+              </div>
+            </m.div>
+          )}
+
+          {/* RESULTS */}
+          {view === "results" && quote && (
+            <m.div key="results" {...fade()}>
+              <QuoteResults quote={quote} onRefine={handleRefine} />
+            </m.div>
+          )}
+
+          {/* ERROR */}
+          {view === "error" && (
+            <m.div
+              key="error"
+              {...fade()}
+              className="flex flex-col items-center justify-center py-32"
+            >
+              <div className="rounded-2xl border border-gi-line bg-white shadow-gi p-8 max-w-md text-center">
+                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
+                  <svg
+                    className="h-6 w-6 text-red-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+                    />
+                  </svg>
+                </div>
+                <h2 className="text-lg font-semibold text-gi-navy mb-2">
+                  Something went wrong
+                </h2>
+                <p className="text-sm text-gi-navy/60 mb-6">{errorMessage}</p>
+                <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                  <button
+                    onClick={handleTryAgain}
+                    className="btn-primary"
+                  >
+                    Try again
+                  </button>
+                  <Link href="/contact/" className="btn-secondary">
+                    Contact Green Irony
+                  </Link>
+                </div>
+              </div>
+            </m.div>
+          )}
+        </AnimatePresence>
+      </main>
+    </PortalShell>
+  );
+}


### PR DESCRIPTION
Multi-page portal with dashboard (quote list), new quote flow (input → generating → results → error), and quote detail view. Typed API service layer stubbed with mock data, ready for MuleSoft swap. Shared PortalShell layout, QuoteResults component, confidence badge styling, inactivity timeout, and 501 API route stubs.