### PR TITLE
Fix auth race condition and add auto-signout on token expiry

### DIFF
--- a/lib/portal/quoteService.ts
+++ b/lib/portal/quoteService.ts
@@ -1,3 +1,4 @@
+import { signOut } from "next-auth/react";
 import type {
   ApiResult,
   GenerateQuoteInput,
@@ -8,6 +9,27 @@ import type {
 import { MOCK_QUOTES, MOCK_QUOTE_LIST } from "./mockData";
 
 const USE_MOCK = !process.env.NEXT_PUBLIC_PORTAL_API_ENABLED;
+
+/**
+ * Wrapper around fetch that auto-signs the user out when the API returns
+ * 403 with code TOKEN_EXPIRED. This means MuleSoft rejected the Google
+ * id_token (expired or invalid) — as opposed to 401 which is a local
+ * NextAuth cookie issue (e.g. brief race on first load).
+ */
+async function portalFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status === 403) {
+    const body = await res.clone().json().catch(() => ({}));
+    if (body.code === "TOKEN_EXPIRED") {
+      signOut({ callbackUrl: "/portal/sign-in/" });
+      throw new Error("Session expired");
+    }
+  }
+  return res;
+}
 
 // Track mock quote IDs that have been "polled" at least once, so the second
 // poll returns completed data (simulates async generation).
@@ -47,7 +69,7 @@ export async function generateQuote(
       }
     }
 
-    const res = await fetch("/api/portal/quote", {
+    const res = await portalFetch("/api/portal/quote", {
       method: "POST",
       body: formData,
     });
@@ -104,7 +126,7 @@ export async function getQuote(
   }
 
   try {
-    const res = await fetch(`/api/portal/quotes/${encodeURIComponent(id)}`);
+    const res = await portalFetch(`/api/portal/quotes/${encodeURIComponent(id)}`);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       return { ok: false, message: body.message || "Failed to load quote" };
@@ -122,7 +144,7 @@ export async function listQuotes(): Promise<ApiResult<QuoteListItem[]>> {
   }
 
   try {
-    const res = await fetch("/api/portal/quotes");
+    const res = await portalFetch("/api/portal/quotes");
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       return { ok: false, message: body.message || "Failed to load quotes" };

--- a/pages/api/portal/quote.ts
+++ b/pages/api/portal/quote.ts
@@ -39,6 +39,9 @@ export default async function handler(
     const body = await readRawBody(req);
     const accessToken = token.idToken as string | undefined;
     const result = await proxyPostFormData("/quote", body, contentType, accessToken);
+    if (result.status === 401) {
+      return res.status(403).json({ message: "Session expired", code: "TOKEN_EXPIRED" });
+    }
     return res.status(result.status).json(result.data);
   } catch (err) {
     console.error("POST /api/portal/quote proxy error:", err);

--- a/pages/api/portal/quotes.ts
+++ b/pages/api/portal/quotes.ts
@@ -23,6 +23,10 @@ export default async function handler(
   try {
     const accessToken = token.idToken as string | undefined;
     const result = await proxyGet("/quotes", accessToken);
+    // MuleSoft rejected the token — signal expiry to the client as 403
+    if (result.status === 401) {
+      return res.status(403).json({ message: "Session expired", code: "TOKEN_EXPIRED" });
+    }
     return res.status(result.status).json(result.data);
   } catch (err) {
     console.error("GET /api/portal/quotes proxy error:", err);

--- a/pages/api/portal/quotes/[id].ts
+++ b/pages/api/portal/quotes/[id].ts
@@ -29,6 +29,9 @@ export default async function handler(
     const accessToken = token.idToken as string | undefined;
     // API uses /quote/{id} (singular), not /quotes/{id}
     const result = await proxyGet(`/quote/${encodeURIComponent(id)}`, accessToken);
+    if (result.status === 401) {
+      return res.status(403).json({ message: "Session expired", code: "TOKEN_EXPIRED" });
+    }
     return res.status(result.status).json(result.data);
   } catch (err) {
     console.error("GET /api/portal/quotes/[id] proxy error:", err);

--- a/pages/portal/index.tsx
+++ b/pages/portal/index.tsx
@@ -29,7 +29,7 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export default function PortalDashboard() {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const router = useRouter();
   const prefersReduced = useReducedMotion();
   const reduced = !!prefersReduced;
@@ -41,6 +41,7 @@ export default function PortalDashboard() {
   const firstName = session?.user?.name?.split(" ")[0] ?? "there";
 
   useEffect(() => {
+    if (sessionStatus !== "authenticated") return;
     listQuotes().then((result) => {
       if (result.ok && result.data) {
         setQuotes(result.data);
@@ -49,7 +50,7 @@ export default function PortalDashboard() {
       }
       setLoading(false);
     });
-  }, []);
+  }, [sessionStatus]);
 
   const fade = {
     initial: reduced ? { opacity: 0 } : { opacity: 0, y: 16 },


### PR DESCRIPTION
- Wait for authenticated session before fetching quotes on dashboard
- Add portalFetch wrapper that auto-signs out when MuleSoft rejects an expired token (403 TOKEN_EXPIRED) without triggering on transient 401s
- API routes now return 403 TOKEN_EXPIRED for upstream auth failures, keeping 401 for local NextAuth cookie issues