### PR TITLE
SEO/AEO: per-page meta, sitemap, llms.txt, /insights/ SSR

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,35 +1,38 @@
 export function getBaseUrl(): string {
-  const envUrl = process.env.NEXT_PUBLIC_SITE_URL || '';
-  if (!envUrl) return '';
+  // Production fallback guards against silent canonical/hreflang regressions
+  // when NEXT_PUBLIC_SITE_URL is missing from a deploy environment.
+  const productionFallback =
+    process.env.NODE_ENV === "production" ? "https://greenirony.com" : "";
+  const envUrl = process.env.NEXT_PUBLIC_SITE_URL || productionFallback;
+  if (!envUrl) return "";
   try {
     const url = new URL(envUrl);
-    // Always ensure trailing slash
-    return url.origin + '/';
+    return url.origin + "/";
   } catch {
-    return '';
+    return "";
   }
 }
 
 export function buildCanonicalUrl(pathname: string): string {
   const base = getBaseUrl();
-  if (!base) return '';
+  if (!base) return "";
   // Remove query/hash and normalize leading/trailing slashes
-  let raw = pathname || '/';
+  let raw = pathname || "/";
   // Drop query/hash if present
-  raw = raw.split('#')[0].split('?')[0] || '/';
+  raw = raw.split("#")[0].split("?")[0] || "/";
   // Ensure leading slash
-  if (!raw.startsWith('/')) raw = `/${raw}`;
+  if (!raw.startsWith("/")) raw = `/${raw}`;
   // Determine if looks like a file (keep as-is)
   const seemsFile = /\.[a-z0-9]{2,8}$/i.test(raw);
   // Enforce trailing slash for page routes to match Next.js trailingSlash config
-  if (!seemsFile && !raw.endsWith('/')) raw = `${raw}/`;
+  if (!seemsFile && !raw.endsWith("/")) raw = `${raw}/`;
   // Collapse duplicate slashes
-  raw = raw.replace(/\/+/g, '/');
+  raw = raw.replace(/\/+/g, "/");
   return new URL(raw, base).toString();
 }
 
 export function toAbsoluteUrl(input: string | undefined | null): string {
-  if (!input) return '';
+  if (!input) return "";
   try {
     // Already absolute
     const u = new URL(input);
@@ -38,7 +41,10 @@ export function toAbsoluteUrl(input: string | undefined | null): string {
     const base = getBaseUrl();
     if (!base) return input;
     try {
-      return new URL(input.startsWith('/') ? input : `/${input}`, base).toString();
+      return new URL(
+        input.startsWith("/") ? input : `/${input}`,
+        base,
+      ).toString();
     } catch {
       return input;
     }
@@ -50,9 +56,13 @@ export function toAbsoluteUrl(input: string | undefined | null): string {
  * - If the base title exceeds maxChars, truncate with an ellipsis.
  * - If the base title plus suffix exceeds maxChars, omit the suffix.
  */
-export function generateSeoTitle(baseTitle: string, siteTitle?: string, maxChars: number = 60): string {
-  const title = (baseTitle || '').trim();
-  const suffix = siteTitle ? ` - ${siteTitle}` : '';
+export function generateSeoTitle(
+  baseTitle: string,
+  siteTitle?: string,
+  maxChars: number = 60,
+): string {
+  const title = (baseTitle || "").trim();
+  const suffix = siteTitle ? ` - ${siteTitle}` : "";
 
   if (title.length > maxChars) {
     const truncated = title.slice(0, Math.max(1, maxChars - 1)).trimEnd();
@@ -65,5 +75,3 @@ export function generateSeoTitle(baseTitle: string, siteTitle?: string, maxChars
 
   return title;
 }
-
-

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,13 +31,13 @@ export default function MyApp({ Component, pageProps }) {
   useEffect(() => {
     if (!GA_MEASUREMENT_ID) return;
     const handleRouteChange = (url) => {
-      if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-        window.gtag('config', GA_MEASUREMENT_ID, { page_path: url });
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("config", GA_MEASUREMENT_ID, { page_path: url });
       }
     };
-    router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on("routeChangeComplete", handleRouteChange);
     return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
+      router.events.off("routeChangeComplete", handleRouteChange);
     };
   }, [router.events, GA_MEASUREMENT_ID]);
 
@@ -45,18 +45,18 @@ export default function MyApp({ Component, pageProps }) {
   useEffect(() => {
     if (!HS_PORTAL_ID) return;
     const handleRouteChange = (url) => {
-      if (typeof window !== 'undefined' && Array.isArray(window._hsq)) {
-        window._hsq.push(['setPath', url]);
-        window._hsq.push(['trackPageView']);
+      if (typeof window !== "undefined" && Array.isArray(window._hsq)) {
+        window._hsq.push(["setPath", url]);
+        window._hsq.push(["trackPageView"]);
       }
     };
-    router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on("routeChangeComplete", handleRouteChange);
     return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
+      router.events.off("routeChangeComplete", handleRouteChange);
     };
   }, [router.events, HS_PORTAL_ID]);
 
-  const isPortal = router.pathname.startsWith('/portal');
+  const isPortal = router.pathname.startsWith("/portal");
 
   return (
     <SessionProvider session={pageProps.session}>
@@ -72,7 +72,7 @@ export default function MyApp({ Component, pageProps }) {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ''}', { anonymize_ip: true${process.env.NODE_ENV !== 'production' ? ', debug_mode: true' : ''} });
+              gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ""}', { anonymize_ip: true${process.env.NODE_ENV !== "production" ? ", debug_mode: true" : ""} });
             `}
           </Script>
         </>
@@ -87,28 +87,51 @@ export default function MyApp({ Component, pageProps }) {
       ) : null}
       <Head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+        />
         <meta name="robots" content="index,follow" />
         <meta name="theme-color" content="#5AAD5A" />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content="website" key="og:type" />
         <meta property="og:site_name" content="Green Irony" />
         <meta property="og:locale" content="en_US" />
-        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:card"
+          content="summary_large_image"
+          key="twitter:card"
+        />
         <meta name="application-name" content="Green Irony" />
         {faviconHref ? (
           <link rel="icon" href={faviconHref} />
         ) : (
-          <link rel="icon" href="/logos/green-irony/banksy-solo-transparent.png" type="image/png" />
+          <link
+            rel="icon"
+            href="/logos/green-irony/banksy-solo-transparent.png"
+            type="image/png"
+          />
         )}
         {/* Canonical URL */}
         {buildCanonicalUrl(router.asPath) ? (
-          <link rel="canonical" href={buildCanonicalUrl(router.asPath)} key="canonical" />
+          <link
+            rel="canonical"
+            href={buildCanonicalUrl(router.asPath)}
+            key="canonical"
+          />
         ) : null}
         {/* Hreflang (single-locale site) */}
         {buildCanonicalUrl(router.asPath) ? (
           <>
-            <link rel="alternate" hrefLang="en" href={buildCanonicalUrl(router.asPath)} />
-            <link rel="alternate" hrefLang="x-default" href={buildCanonicalUrl(router.asPath)} />
+            <link
+              rel="alternate"
+              hrefLang="en"
+              href={buildCanonicalUrl(router.asPath)}
+            />
+            <link
+              rel="alternate"
+              hrefLang="x-default"
+              href={buildCanonicalUrl(router.asPath)}
+            />
           </>
         ) : null}
         {/* Global Organization & WebSite JSON-LD */}
@@ -120,8 +143,10 @@ export default function MyApp({ Component, pageProps }) {
               "@context": "https://schema.org",
               "@type": "Organization",
               name: "Green Irony",
-              url: toAbsoluteUrl('/') || undefined,
-              logo: toAbsoluteUrl('/logos/green-irony/Green-Irony-Logo.svg') || undefined,
+              url: toAbsoluteUrl("/") || undefined,
+              logo:
+                toAbsoluteUrl("/logos/green-irony/Green-Irony-Logo.svg") ||
+                undefined,
               sameAs: [],
             }),
           }}
@@ -134,10 +159,12 @@ export default function MyApp({ Component, pageProps }) {
               "@context": "https://schema.org",
               "@type": "WebSite",
               name: "Green Irony",
-              url: toAbsoluteUrl('/') || undefined,
+              url: toAbsoluteUrl("/") || undefined,
               potentialAction: {
                 "@type": "SearchAction",
-                target: toAbsoluteUrl('/insights?q={search_term_string}') || undefined,
+                target:
+                  toAbsoluteUrl("/insights?q={search_term_string}") ||
+                  undefined,
                 "query-input": "required name=search_term_string",
               },
             }),
@@ -145,8 +172,21 @@ export default function MyApp({ Component, pageProps }) {
         />
       </Head>
       <FaustProvider pageProps={pageProps}>
-        <div className="min-h-screen flex flex-col" style={isPortal ? undefined : { paddingTop: 'var(--gi-header-offset,64px)' }}>
-          {!isPortal && <style jsx global>{`:root{--gi-header-offset:64px}`}</style>}
+        <div
+          className="min-h-screen flex flex-col"
+          style={
+            isPortal
+              ? undefined
+              : { paddingTop: "var(--gi-header-offset,64px)" }
+          }
+        >
+          {!isPortal && (
+            <style jsx global>{`
+              :root {
+                --gi-header-offset: 64px;
+              }
+            `}</style>
+          )}
           {isPortal ? (
             <PortalAccessProvider>
               <Component {...pageProps} key={router.asPath} />

--- a/pages/insights.tsx
+++ b/pages/insights.tsx
@@ -16,7 +16,11 @@ import { HEADER_MENU_QUERY } from "../queries/MenuQueries";
 import React from "react";
 import { loadAllStories } from "../lib/customerStories";
 
-// Simple latest posts query (9 most recent)
+// We pass first: 500 below to fetch all posts in one shot so every blog
+// URL appears in the SSR HTML. Image bytes are still deferred client-side
+// via next/image, so rendering all tiles costs only ~25KB of extra HTML.
+
+// Latest posts query
 export const LATEST_POSTS_QUERY = gql`
   ${POST_LIST_FRAGMENT}
   query LatestPosts(
@@ -117,7 +121,7 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
     refetch,
   } = useQuery(LATEST_POSTS_QUERY, {
     variables: {
-      first: 9,
+      first: 500,
       after: null,
       categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined,
       search: debouncedQ || undefined,
@@ -142,7 +146,7 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
   React.useEffect(() => {
     // Keep current posts visible while refetching to avoid UI flicker to stories-only
     refetch({
-      first: 9,
+      first: 500,
       after: null,
       categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined,
       search: debouncedQ || undefined,
@@ -166,7 +170,7 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
     try {
       const res = await fetchMore({
         variables: {
-          first: 9,
+          first: 500,
           after: pageInfo?.endCursor,
           categoryIn: selectedCategoryIds.length
             ? selectedCategoryIds
@@ -626,7 +630,7 @@ export async function getStaticProps(_context: any) {
     apolloClient.query({
       query: LATEST_POSTS_QUERY,
       variables: {
-        first: 9,
+        first: 500,
         after: null,
         categoryIn: undefined,
         search: undefined,

--- a/pages/insights.tsx
+++ b/pages/insights.tsx
@@ -1,28 +1,48 @@
-import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { buildCanonicalUrl, toAbsoluteUrl } from '../lib/seo';
-import Header from '../components/Header';
-import Footer from '../components/Footer';
-import InsightsHeroSearch from '../components/InsightsHeroSearch';
-import FeaturedPost from '../components/FeaturedPost';
-import CombinedTile, { CombinedItem } from '../components/CombinedTile';
-import CustomerStoryCard from '../components/CustomerStoryCard';
-import { gql, useQuery } from '@apollo/client';
-import PostTile from '../components/PostTile';
-import { POST_LIST_FRAGMENT } from '../fragments/PostListFragment';
-import { getNextStaticProps } from '@faustwp/core';
-import { SITE_DATA_QUERY } from '../queries/SiteSettingsQuery';
-import { HEADER_MENU_QUERY } from '../queries/MenuQueries';
-import React from 'react';
-import { loadAllStories } from '../lib/customerStories';
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { buildCanonicalUrl, toAbsoluteUrl } from "../lib/seo";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import InsightsHeroSearch from "../components/InsightsHeroSearch";
+import FeaturedPost from "../components/FeaturedPost";
+import CombinedTile, { CombinedItem } from "../components/CombinedTile";
+import CustomerStoryCard from "../components/CustomerStoryCard";
+import { gql, useQuery } from "@apollo/client";
+import PostTile from "../components/PostTile";
+import { POST_LIST_FRAGMENT } from "../fragments/PostListFragment";
+import { getApolloClient, addApolloState } from "@faustwp/core";
+import { SITE_DATA_QUERY } from "../queries/SiteSettingsQuery";
+import { HEADER_MENU_QUERY } from "../queries/MenuQueries";
+import React from "react";
+import { loadAllStories } from "../lib/customerStories";
 
 // Simple latest posts query (9 most recent)
 export const LATEST_POSTS_QUERY = gql`
   ${POST_LIST_FRAGMENT}
-  query LatestPosts($first: Int!, $after: String, $categoryIn: [ID], $search: String) {
-    posts(first: $first, after: $after, where: { orderby: { field: DATE, order: DESC }, status: PUBLISH, categoryIn: $categoryIn, search: $search }) {
-      pageInfo { hasNextPage endCursor }
-      nodes { ...PostListFragment databaseId }
+  query LatestPosts(
+    $first: Int!
+    $after: String
+    $categoryIn: [ID]
+    $search: String
+  ) {
+    posts(
+      first: $first
+      after: $after
+      where: {
+        orderby: { field: DATE, order: DESC }
+        status: PUBLISH
+        categoryIn: $categoryIn
+        search: $search
+      }
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        ...PostListFragment
+        databaseId
+      }
     }
   }
 `;
@@ -30,7 +50,13 @@ export const LATEST_POSTS_QUERY = gql`
 export const CATEGORIES_QUERY = gql`
   query InsightCategories {
     categories(where: { hideEmpty: true }, first: 100) {
-      nodes { id databaseId name slug count }
+      nodes {
+        id
+        databaseId
+        name
+        slug
+        count
+      }
     }
   }
 `;
@@ -38,8 +64,14 @@ export const CATEGORIES_QUERY = gql`
 export const FEATURED_STICKY_POST_QUERY = gql`
   ${POST_LIST_FRAGMENT}
   query FeaturedStickyPost {
-    posts(first: 100, where: { orderby: { field: DATE, order: DESC }, status: PUBLISH }) {
-      nodes { ...PostListFragment databaseId }
+    posts(
+      first: 100
+      where: { orderby: { field: DATE, order: DESC }, status: PUBLISH }
+    ) {
+      nodes {
+        ...PostListFragment
+        databaseId
+      }
     }
   }
 `;
@@ -60,34 +92,61 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
   const headerMenuDataQuery = useQuery(HEADER_MENU_QUERY) || {};
 
   const siteData = siteDataQuery?.data?.generalSettings || {};
-  const menuItems = headerMenuDataQuery?.data?.primaryMenuItems?.nodes || { nodes: [] };
+  const menuItems = headerMenuDataQuery?.data?.primaryMenuItems?.nodes || {
+    nodes: [],
+  };
   const { title: siteTitle, description: siteDescription } = siteData;
   const router = useRouter();
-  const canonical = buildCanonicalUrl(router?.asPath || '/insights/');
-  const pageTitle = siteTitle ? `${siteTitle} — Clarity in the age of AI` : 'Clarity in the age of AI';
-  const metaDescription = 'Insights, playbooks, and customer stories on AI-native delivery, integration foundations, and getting a working agent live fast.';
+  const canonical = buildCanonicalUrl(router?.asPath || "/insights/");
+  const pageTitle = siteTitle
+    ? `${siteTitle} — Clarity in the age of AI`
+    : "Clarity in the age of AI";
+  const metaDescription =
+    "Insights, playbooks, and customer stories on AI-native delivery, integration foundations, and getting a working agent live fast.";
 
-  const [selectedCategoryIds, setSelectedCategoryIds] = React.useState<number[]>([]);
-  const [q, setQ] = React.useState<string>('');
+  const [selectedCategoryIds, setSelectedCategoryIds] = React.useState<
+    number[]
+  >([]);
+  const [q, setQ] = React.useState<string>("");
   const debouncedQ = useDebouncedValue(q, 300);
 
-  const { data: postsData, error: postsError, fetchMore, refetch } = useQuery(LATEST_POSTS_QUERY, {
-    variables: { first: 9, after: null, categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined, search: debouncedQ || undefined },
+  const {
+    data: postsData,
+    error: postsError,
+    fetchMore,
+    refetch,
+  } = useQuery(LATEST_POSTS_QUERY, {
+    variables: {
+      first: 9,
+      after: null,
+      categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined,
+      search: debouncedQ || undefined,
+    },
     notifyOnNetworkStatusChange: true,
-    fetchPolicy: 'cache-first',
-    nextFetchPolicy: 'cache-first',
+    fetchPolicy: "cache-first",
+    nextFetchPolicy: "cache-first",
   });
   const initialPosts = postsData?.posts?.nodes || [];
   const initialPageInfo = postsData?.posts?.pageInfo;
 
-  const [accPosts, setAccPosts] = React.useState<any[]>([]);
-  const [pageInfo, setPageInfo] = React.useState<{ hasNextPage: boolean; endCursor: string | null } | undefined>(undefined);
+  // Lazy-init from prefetched cache so the first render — including SSR —
+  // already has post tiles. Crawlers read SSR HTML; an empty initial state
+  // means zero post discoverability from the index.
+  const [accPosts, setAccPosts] = React.useState<any[]>(() => initialPosts);
+  const [pageInfo, setPageInfo] = React.useState<
+    { hasNextPage: boolean; endCursor: string | null } | undefined
+  >(() => initialPageInfo);
   const loadingMoreRef = React.useRef(false);
   const sentinelRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     // Keep current posts visible while refetching to avoid UI flicker to stories-only
-    refetch({ first: 9, after: null, categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined, search: debouncedQ || undefined });
+    refetch({
+      first: 9,
+      after: null,
+      categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined,
+      search: debouncedQ || undefined,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCategoryIds, debouncedQ]);
 
@@ -109,7 +168,9 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
         variables: {
           first: 9,
           after: pageInfo?.endCursor,
-          categoryIn: selectedCategoryIds.length ? selectedCategoryIds : undefined,
+          categoryIn: selectedCategoryIds.length
+            ? selectedCategoryIds
+            : undefined,
           search: debouncedQ || undefined,
         },
       });
@@ -117,8 +178,12 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
       const nextInfo = res?.data?.posts?.pageInfo;
       if (newNodes.length > 0) {
         setAccPosts((prev) => {
-          const existingIds = new Set(prev.map((p: any) => p.databaseId || p.id));
-          const deduped = newNodes.filter((p: any) => !existingIds.has(p.databaseId || p.id));
+          const existingIds = new Set(
+            prev.map((p: any) => p.databaseId || p.id),
+          );
+          const deduped = newNodes.filter(
+            (p: any) => !existingIds.has(p.databaseId || p.id),
+          );
           return [...prev, ...deduped];
         });
       }
@@ -131,22 +196,37 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
   React.useEffect(() => {
     const el = sentinelRef.current;
     if (!el) return;
-    const io = new IntersectionObserver((entries) => {
-      const [e] = entries;
-      if (e.isIntersecting) loadMore();
-    }, { rootMargin: '200px' });
+    const io = new IntersectionObserver(
+      (entries) => {
+        const [e] = entries;
+        if (e.isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" },
+    );
     io.observe(el);
     return () => io.disconnect();
   }, [pageInfo?.endCursor]);
 
-  const { data: featuredData } = useQuery(FEATURED_STICKY_POST_QUERY, { fetchPolicy: 'no-cache', nextFetchPolicy: 'cache-first' });
-  const featuredPost = (featuredData?.posts?.nodes || []).find((p: any) => p?.isSticky);
+  const { data: featuredData } = useQuery(FEATURED_STICKY_POST_QUERY, {
+    fetchPolicy: "cache-first",
+    nextFetchPolicy: "cache-first",
+  });
+  const featuredPost = (featuredData?.posts?.nodes || []).find(
+    (p: any) => p?.isSticky,
+  );
 
   const { data: catsData } = useQuery(CATEGORIES_QUERY);
-  const categories: Array<{ name: string; databaseId: number; slug: string; count: number }> = catsData?.categories?.nodes || [];
+  const categories: Array<{
+    name: string;
+    databaseId: number;
+    slug: string;
+    count: number;
+  }> = catsData?.categories?.nodes || [];
 
   function toggleCategory(id: number) {
-    setSelectedCategoryIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    setSelectedCategoryIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
   }
   function clearFilters() {
     setSelectedCategoryIds([]);
@@ -154,41 +234,63 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
 
   // Modernized Filters UI (modal)
   const [filtersOpen, setFiltersOpen] = React.useState(false);
-  function openFilters() { setFiltersOpen(true); }
-  function applyFilters() { setFiltersOpen(false); }
+  function openFilters() {
+    setFiltersOpen(true);
+  }
+  function applyFilters() {
+    setFiltersOpen(false);
+  }
 
   // Build combined list (posts + stories)
   const normalizedPosts: CombinedItem[] = (accPosts || []).map((p: any) => ({
     id: p.id,
-    type: 'post',
+    type: "post",
     title: p.title,
-    href: p.uri && !p.uri.startsWith('?p=') ? p.uri : (p.slug ? `/blog/${p.slug}/` : '#'),
+    href:
+      p.uri && !p.uri.startsWith("?p=")
+        ? p.uri
+        : p.slug
+          ? `/blog/${p.slug}/`
+          : "#",
     date: p.date,
-    image: p.featuredImage?.node?.sourceUrl ? { src: p.featuredImage.node.sourceUrl, alt: p.featuredImage?.node?.altText } : undefined,
+    image: p.featuredImage?.node?.sourceUrl
+      ? {
+          src: p.featuredImage.node.sourceUrl,
+          alt: p.featuredImage?.node?.altText,
+        }
+      : undefined,
     tags: (p.categories?.nodes || []).map((c: any) => c.name),
-    searchText: `${p.title || ''} ${(p.excerpt || '').replace(/<[^>]+>/g,' ')} ${((p.categories?.nodes||[]).map((c:any)=>c.name).join(' '))}`.toLowerCase(),
+    searchText:
+      `${p.title || ""} ${(p.excerpt || "").replace(/<[^>]+>/g, " ")} ${(p.categories?.nodes || []).map((c: any) => c.name).join(" ")}`.toLowerCase(),
   }));
-  const normalizedStories: CombinedItem[] = (props.stories || []).map((s: any) => ({
-    id: s.slug,
-    type: 'story',
-    title: s.title,
-    href: `/customer-stories/${s.slug}`,
-    date: s.datePublished,
-    image: s.image?.src ? { src: s.image.src, alt: s.image?.alt } : undefined,
-    tags: s.tags || [],
-    searchText: `${s.title || ''} ${s.excerpt || ''} ${(s.tags||[]).join(' ')} ${s.brand || ''} ${(s.products||[]).join(' ')} ${s.vertical || ''}`.toLowerCase(),
-  }));
+  const normalizedStories: CombinedItem[] = (props.stories || []).map(
+    (s: any) => ({
+      id: s.slug,
+      type: "story",
+      title: s.title,
+      href: `/customer-stories/${s.slug}`,
+      date: s.datePublished,
+      image: s.image?.src ? { src: s.image.src, alt: s.image?.alt } : undefined,
+      tags: s.tags || [],
+      searchText:
+        `${s.title || ""} ${s.excerpt || ""} ${(s.tags || []).join(" ")} ${s.brand || ""} ${(s.products || []).join(" ")} ${s.vertical || ""}`.toLowerCase(),
+    }),
+  );
 
   // Base combined list (full set). Thresholding for jank avoidance is applied later when no search query.
   const combinedAll = React.useMemo(() => {
     const posts = (normalizedPosts || []).filter((p) => !!p.date);
     const stories = (normalizedStories || []).filter((s) => !!s.date);
     const list = [...posts, ...stories];
-    return list.sort((a, b) => (new Date(b.date).getTime() - new Date(a.date).getTime()));
+    return list.sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    );
   }, [normalizedPosts, normalizedStories]);
 
   // Type + Topics filters
-  const [selectedType, setSelectedType] = React.useState<'all' | 'post' | 'story'>('all');
+  const [selectedType, setSelectedType] = React.useState<
+    "all" | "post" | "story"
+  >("all");
   const allTopics = React.useMemo(() => {
     const set = new Set<string>();
     normalizedPosts.forEach((p) => (p.tags || []).forEach((t) => set.add(t)));
@@ -199,36 +301,58 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
 
   const filteredCombined = React.useMemo(() => {
     let items = combinedAll;
-    const hasTypeFilter = selectedType !== 'all';
+    const hasTypeFilter = selectedType !== "all";
     const hasTopicFilter = selectedTopics.length > 0;
-    const q = (debouncedQ || '').toLowerCase();
+    const q = (debouncedQ || "").toLowerCase();
     const hasSearch = !!q;
 
     if (hasTypeFilter) items = items.filter((i) => i.type === selectedType);
-    if (hasTopicFilter) items = items.filter((i) => (i.tags || []).some((t) => selectedTopics.includes(t)));
-    if (hasSearch) items = items.filter((i) => (i.searchText || i.title?.toLowerCase()).includes(q));
+    if (hasTopicFilter)
+      items = items.filter((i) =>
+        (i.tags || []).some((t) => selectedTopics.includes(t)),
+      );
+    if (hasSearch)
+      items = items.filter((i) =>
+        (i.searchText || i.title?.toLowerCase()).includes(q),
+      );
 
     // Apply threshold ONLY in the unfiltered, no-search, browsing state (to prevent lazy-load jank)
     if (!hasTypeFilter && !hasTopicFilter && !hasSearch) {
-      const posts = items.filter((i) => i.type === 'post');
+      const posts = items.filter((i) => i.type === "post");
       if (posts.length === 0) return items; // nothing to threshold yet
-      const oldestPostDate = posts.reduce((min, p) => (new Date(p.date) < new Date(min) ? p.date : min), posts[0].date);
-      return items.filter((i) => i.type === 'story' ? (new Date(i.date) >= new Date(oldestPostDate)) : true);
+      const oldestPostDate = posts.reduce(
+        (min, p) => (new Date(p.date) < new Date(min) ? p.date : min),
+        posts[0].date,
+      );
+      return items.filter((i) =>
+        i.type === "story"
+          ? new Date(i.date) >= new Date(oldestPostDate)
+          : true,
+      );
     }
 
     return items;
   }, [combinedAll, selectedType, selectedTopics, debouncedQ]);
 
-  const isBrowsingNoFilters = selectedType === 'all' && selectedTopics.length === 0 && !debouncedQ;
+  const isBrowsingNoFilters =
+    selectedType === "all" && selectedTopics.length === 0 && !debouncedQ;
   const postsLoaded = (accPosts || []).length > 0;
 
   // Build ItemList JSON-LD for initial items (up to 10)
-  const itemList = (accPosts || []).slice(0, 10).map((p: any, idx: number) => ({
-    '@type': 'ListItem',
-    position: idx + 1,
-    url: p?.uri && !p.uri.startsWith('?p=') ? p.uri : (p?.slug ? `/blog/${p.slug}/` : undefined),
-    name: p?.title,
-  })).filter((x: any) => !!x.url);
+  const itemList = (accPosts || [])
+    .slice(0, 10)
+    .map((p: any, idx: number) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      url:
+        p?.uri && !p.uri.startsWith("?p=")
+          ? p.uri
+          : p?.slug
+            ? `/blog/${p.slug}/`
+            : undefined,
+      name: p?.title,
+    }))
+    .filter((x: any) => !!x.url);
 
   return (
     <>
@@ -239,17 +363,32 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
         {canonical ? <meta property="og:url" content={canonical} /> : null}
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={metaDescription} />
-        <meta property="og:image" content={toAbsoluteUrl('/logos/green-irony/green-logo-long.png')} />
+        <meta
+          property="og:image"
+          content={toAbsoluteUrl("/logos/green-irony/green-logo-long.png")}
+        />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={metaDescription} />
-        <meta name="twitter:image" content={toAbsoluteUrl('/logos/green-irony/green-logo-long.png')} />
-        <link rel="alternate" type="application/rss+xml" title="Green Irony Insights" href="/insights/rss.xml" />
+        <meta
+          name="twitter:image"
+          content={toAbsoluteUrl("/logos/green-irony/green-logo-long.png")}
+        />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Green Irony Insights"
+          href="/insights/rss.xml"
+        />
         {itemList.length > 0 ? (
           <script
             type="application/ld+json"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify({ '@context': 'https://schema.org', '@type': 'ItemList', itemListElement: itemList }),
+              __html: JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "ItemList",
+                itemListElement: itemList,
+              }),
             }}
           />
         ) : null}
@@ -258,26 +397,33 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'Blog',
-              name: 'Green Irony Insights',
+              "@context": "https://schema.org",
+              "@type": "Blog",
+              name: "Green Irony Insights",
               url: canonical || undefined,
               description: metaDescription,
-              publisher: { '@type': 'Organization', name: 'Green Irony', url: toAbsoluteUrl('/') || undefined },
+              publisher: {
+                "@type": "Organization",
+                name: "Green Irony",
+                url: toAbsoluteUrl("/") || undefined,
+              },
             }),
           }}
         />
       </Head>
-      <Header siteTitle={siteTitle} siteDescription={siteDescription} menuItems={menuItems} />
+      <Header
+        siteTitle={siteTitle}
+        siteDescription={siteDescription}
+        menuItems={menuItems}
+      />
       <main>
-
         <InsightsHeroSearch
           value={q}
           onChange={setQ}
-          onClear={() => setQ('')}
+          onClear={() => setQ("")}
         />
 
-{featuredPost ? (
+        {featuredPost ? (
           <section className="mx-auto max-w-7xl px-6 py-6">
             <FeaturedPost post={featuredPost} />
           </section>
@@ -287,7 +433,13 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
           {/* Filters button (right-aligned) + selected chips */}
           <div className="mb-6">
             <div className="flex items-center justify-end">
-              <button type="button" onClick={openFilters} className="btn-secondary">Filters</button>
+              <button
+                type="button"
+                onClick={openFilters}
+                className="btn-secondary"
+              >
+                Filters
+              </button>
             </div>
             {selectedCategoryIds.length > 0 ? (
               <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -295,20 +447,37 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
                   const c = categories.find((x) => x.databaseId === id);
                   if (!c) return null;
                   return (
-                    <span key={c.slug} className="inline-flex items-center rounded-full bg-gi-green/15 px-3 py-1 text-sm text-gi-text ring-1 ring-gi-fog">
+                    <span
+                      key={c.slug}
+                      className="inline-flex items-center rounded-full bg-gi-green/15 px-3 py-1 text-sm text-gi-text ring-1 ring-gi-fog"
+                    >
                       {c.name}
-                      <button onClick={() => toggleCategory(c.databaseId)} className="ml-2 text-xs text-gi-gray hover:underline">Remove</button>
+                      <button
+                        onClick={() => toggleCategory(c.databaseId)}
+                        className="ml-2 text-xs text-gi-gray hover:underline"
+                      >
+                        Remove
+                      </button>
                     </span>
                   );
                 })}
-                <button type="button" onClick={clearFilters} className="text-sm text-gi-gray underline">Clear</button>
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="text-sm text-gi-gray underline"
+                >
+                  Clear
+                </button>
               </div>
             ) : null}
           </div>
-          {(!postsLoaded && isBrowsingNoFilters) ? (
+          {!postsLoaded && isBrowsingNoFilters ? (
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 6 }).map((_, i) => (
-                <div key={i} className="overflow-hidden rounded-2xl ring-1 ring-gi-fog bg-white">
+                <div
+                  key={i}
+                  className="overflow-hidden rounded-2xl ring-1 ring-gi-fog bg-white"
+                >
                   <div className="h-40 w-full animate-pulse bg-gi-fog/60" />
                   <div className="p-4">
                     <div className="h-3 w-24 animate-pulse rounded bg-gi-fog/60" />
@@ -319,7 +488,9 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
               ))}
             </div>
           ) : postsError ? (
-            <p className="max-w-3xl text-gi-gray">Error loading content: {String(postsError.message)}</p>
+            <p className="max-w-3xl text-gi-gray">
+              Error loading content: {String(postsError.message)}
+            </p>
           ) : filteredCombined.length === 0 ? (
             <p className="max-w-3xl text-gi-gray">No items found.</p>
           ) : (
@@ -333,24 +504,53 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
         </section>
 
         {filtersOpen ? (
-          <div role="dialog" aria-modal="true" className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4" onClick={() => setFiltersOpen(false)}>
-            <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-gi ring-1 ring-gi-fog" onClick={(e) => e.stopPropagation()}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+            onClick={() => setFiltersOpen(false)}
+          >
+            <div
+              className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-gi ring-1 ring-gi-fog"
+              onClick={(e) => e.stopPropagation()}
+            >
               <div className="mb-4 flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-gi-text">Filter by category</h3>
-                <button className="text-sm text-gi-gray underline" onClick={() => setFiltersOpen(false)}>Close</button>
+                <h3 className="text-lg font-semibold text-gi-text">
+                  Filter by category
+                </h3>
+                <button
+                  className="text-sm text-gi-gray underline"
+                  onClick={() => setFiltersOpen(false)}
+                >
+                  Close
+                </button>
               </div>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 <div className="rounded-lg border p-3">
-                  <div className="text-sm font-semibold text-gi-text mb-2">Type</div>
-                  {(['all','post','story'] as const).map((t) => (
+                  <div className="text-sm font-semibold text-gi-text mb-2">
+                    Type
+                  </div>
+                  {(["all", "post", "story"] as const).map((t) => (
                     <label key={t} className="mr-3 text-sm">
-                      <input type="radio" name="type" className="mr-1" checked={selectedType===t} onChange={() => setSelectedType(t)} />
-                      {t === 'all' ? 'All' : t === 'post' ? 'Blog Posts' : 'Customer Stories'}
+                      <input
+                        type="radio"
+                        name="type"
+                        className="mr-1"
+                        checked={selectedType === t}
+                        onChange={() => setSelectedType(t)}
+                      />
+                      {t === "all"
+                        ? "All"
+                        : t === "post"
+                          ? "Blog Posts"
+                          : "Customer Stories"}
                     </label>
                   ))}
                 </div>
                 <div className="rounded-lg border p-3">
-                  <div className="text-sm font-semibold text-gi-text mb-2">Topics</div>
+                  <div className="text-sm font-semibold text-gi-text mb-2">
+                    Topics
+                  </div>
                   {allTopics.length === 0 ? (
                     <p className="text-sm text-gi-gray">No topics available.</p>
                   ) : (
@@ -358,7 +558,20 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
                       {allTopics.map((t) => {
                         const active = selectedTopics.includes(t);
                         return (
-                          <button key={t} type="button" onClick={() => setSelectedTopics((prev)=> prev.includes(t) ? prev.filter(x=>x!==t) : [...prev, t])} className={`rounded-full px-3 py-1 text-sm ring-1 ${active ? 'bg-gi-green/15 ring-gi-green text-gi-text' : 'bg-white ring-gi-fog text-gi-gray'}`}>{t}</button>
+                          <button
+                            key={t}
+                            type="button"
+                            onClick={() =>
+                              setSelectedTopics((prev) =>
+                                prev.includes(t)
+                                  ? prev.filter((x) => x !== t)
+                                  : [...prev, t],
+                              )
+                            }
+                            className={`rounded-full px-3 py-1 text-sm ring-1 ${active ? "bg-gi-green/15 ring-gi-green text-gi-text" : "bg-white ring-gi-fog text-gi-gray"}`}
+                          >
+                            {t}
+                          </button>
                         );
                       })}
                     </div>
@@ -366,8 +579,25 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
                 </div>
               </div>
               <div className="mt-6 flex flex-wrap items-center justify-end gap-3">
-                <button type="button" className="btn-secondary" onClick={() => { setSelectedType('all'); setSelectedTopics([]); setQ(''); setFiltersOpen(false); }}>Clear</button>
-                <button type="button" className="btn-primary" onClick={applyFilters}>Apply</button>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={() => {
+                    setSelectedType("all");
+                    setSelectedTopics([]);
+                    setQ("");
+                    setFiltersOpen(false);
+                  }}
+                >
+                  Clear
+                </button>
+                <button
+                  type="button"
+                  className="btn-primary"
+                  onClick={applyFilters}
+                >
+                  Apply
+                </button>
               </div>
             </div>
           </div>
@@ -376,16 +606,38 @@ const Page: any = function InsightsPage(props: any & { stories: any[] }) {
       <Footer />
     </>
   );
-}
+};
 
 export default Page;
 
-export async function getStaticProps(context: any) {
+export async function getStaticProps(_context: any) {
+  // Prefetch every query the component reads via useQuery so the Apollo
+  // cache is populated server-side. addApolloState serializes the cache
+  // into pageProps; on the client it gets restored before first render,
+  // so useQuery hooks resolve synchronously from cache and the SSR HTML
+  // contains real post listings (critical for AEO/crawler discovery of
+  // /blog/ URLs through the index).
+  const apolloClient = getApolloClient();
   const stories = loadAllStories();
-  return getNextStaticProps(context, { Page, revalidate: 60, props: { stories } });
-}
 
-(Page as any).queries = [
-  { query: SITE_DATA_QUERY },
-  { query: HEADER_MENU_QUERY },
-] as any; 
+  await Promise.all([
+    apolloClient.query({ query: SITE_DATA_QUERY }),
+    apolloClient.query({ query: HEADER_MENU_QUERY }),
+    apolloClient.query({
+      query: LATEST_POSTS_QUERY,
+      variables: {
+        first: 9,
+        after: null,
+        categoryIn: undefined,
+        search: undefined,
+      },
+    }),
+    apolloClient.query({ query: FEATURED_STICKY_POST_QUERY }),
+    apolloClient.query({ query: CATEGORIES_QUERY }),
+  ]);
+
+  return addApolloState(apolloClient, {
+    props: { stories },
+    revalidate: 60,
+  });
+}

--- a/pages/llms.txt.js
+++ b/pages/llms.txt.js
@@ -1,41 +1,184 @@
-// Non-standard but emerging convention for LLM crawlers (AEO)
-export default function LlmsTxt() { return null; }
+// llms.txt — proposed convention (https://llmstxt.org) for guiding LLM
+// crawlers to the most useful content on a site. Markdown-formatted.
+// Distinct from robots.txt: this is a curated content map, not access rules.
+
+import { getWpUrl } from "@faustwp/core";
+import { loadAllStories } from "../lib/customerStories";
+
+export default function LlmsTxt() {
+  return null;
+}
+
+function escapeMd(s) {
+  return String(s || "")
+    .replace(/\r?\n+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripHtml(s) {
+  return String(s || "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8211;/g, "–")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function clip(s, n) {
+  const t = stripHtml(s);
+  if (t.length <= n) return t;
+  return t.slice(0, n - 1).replace(/\s+\S*$/, "") + "…";
+}
 
 export async function getServerSideProps({ req, res }) {
-  const envBase = process.env.NEXT_PUBLIC_SITE_URL || '';
-  const host = req?.headers?.host || '';
-  const proto = (req?.headers?.['x-forwarded-proto'] || 'https');
-  const origin = envBase || (host ? `${proto}://${host}` : '');
-  const sitemapUrl = origin ? `${origin.replace(/\/$/, '')}/sitemap.xml` : '/sitemap.xml';
+  const envBase = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const host = req?.headers?.host || "";
+  const proto = req?.headers?.["x-forwarded-proto"] || "https";
+  const origin = (
+    envBase || (host ? `${proto}://${host}` : "https://greenirony.com")
+  ).replace(/\/$/, "");
 
-  const body = [
-    '# llms.txt — guidance for AI crawlers',
-    '',
-    // Global group
-    'User-agent: *',
-    'Allow: /',
-    '',
-    // Explicit AI crawler groups
-    'User-agent: GPTBot',
-    'Allow: /',
-    '',
-    'User-agent: ChatGPT-User',
-    'Allow: /',
-    '',
-    'User-agent: Google-Extended',
-    'Allow: /',
-    '',
-    'User-agent: CCBot',
-    'Allow: /',
-    '',
-    `Sitemap: ${sitemapUrl}`,
-    '',
-  ].join('\n');
+  // Pull customer stories (sync, on disk)
+  let stories = [];
+  try {
+    stories = loadAllStories() || [];
+  } catch (err) {
+    console.error("[llms.txt] failed to load customer stories:", err);
+  }
 
-  res.setHeader('Content-Type', 'text/plain');
+  // Pull recent blog posts via WPGraphQL (with excerpts)
+  const wpUrl = getWpUrl();
+  const graphqlEndpoint = `${wpUrl.replace(/\/$/, "")}/graphql`;
+  let posts = [];
+  try {
+    const query = `query LlmsTxtPosts {
+      posts(first: 25, where: { status: PUBLISH, orderby: { field: DATE, order: DESC } }) {
+        nodes { uri slug status title excerpt date }
+      }
+    }`;
+    const resp = await fetch(graphqlEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      posts = (data?.data?.posts?.nodes || [])
+        .filter(
+          (n) =>
+            n?.uri &&
+            !/__trashed/i.test(n.uri) &&
+            !/__trashed/i.test(n.slug || ""),
+        )
+        .map((n) => ({
+          uri: n.uri.startsWith("/") ? n.uri : `/${n.uri}`,
+          title: n.title || "",
+          excerpt: clip(n.excerpt, 180),
+          date: (n.date || "").split("T")[0],
+        }));
+    } else {
+      console.error("[llms.txt] WPGraphQL non-OK response:", resp.status);
+    }
+  } catch (err) {
+    console.error("[llms.txt] WPGraphQL fetch failed:", err);
+  }
+
+  // Build the markdown body per llms.txt spec
+  const lines = [];
+  lines.push("# Green Irony");
+  lines.push("");
+  lines.push(
+    "> Green Irony helps enterprises become AI-native through Salesforce, MuleSoft integration, and Agentforce delivery — turning AI into actual intelligence.",
+  );
+  lines.push("");
+  lines.push(
+    "This document is provided for AI crawlers and grounded-search systems. " +
+      "It curates the most useful URLs on greenirony.com, organized by topic. " +
+      "All URLs are server-rendered HTML with structured metadata (JSON-LD).",
+  );
+  lines.push("");
+
+  // Services
+  lines.push("## Services");
+  lines.push("");
+  lines.push(
+    `- [Agentforce Implementation](${origin}/services/agentforce/): Production-ready Salesforce Agentforce deployment, from architecture to ongoing optimization.`,
+  );
+  lines.push(
+    `- [MuleSoft Integration](${origin}/services/mulesoft/): The integration layer that makes AI work — APIs, event-driven pipelines, system-of-record connections.`,
+  );
+  lines.push(
+    `- [Salesforce Implementation](${origin}/services/salesforce/): Salesforce platform delivery, Sales/Service/Experience Cloud, and managed services.`,
+  );
+  lines.push(
+    `- [Data & Migrations](${origin}/services/data/): Data architecture, migration strategy, and the foundation under any AI initiative.`,
+  );
+  lines.push("");
+
+  // Customer Stories
+  if (stories.length > 0) {
+    lines.push("## Customer Stories");
+    lines.push("");
+    for (const s of stories) {
+      const summary = escapeMd(s.excerpt || s.title || s.brand || "");
+      const desc = summary ? `: ${clip(summary, 200)}` : "";
+      lines.push(
+        `- [${escapeMd(s.brand || s.title || s.slug)}](${origin}/customer-stories/${s.slug}/)${desc}`,
+      );
+    }
+    lines.push("");
+  }
+
+  // Insights / Blog
+  if (posts.length > 0) {
+    lines.push("## Insights");
+    lines.push("");
+    for (const p of posts) {
+      const desc = p.excerpt ? `: ${p.excerpt}` : "";
+      lines.push(
+        `- [${escapeMd(stripHtml(p.title))}](${origin}${p.uri})${desc}`,
+      );
+    }
+    lines.push("");
+  }
+
+  // About
+  lines.push("## About");
+  lines.push("");
+  lines.push(
+    `- [Company](${origin}/about/): Mission, leadership, and how we work.`,
+  );
+  lines.push(`- [Careers](${origin}/careers/): Open roles at Green Irony.`);
+  lines.push(
+    `- [Contact](${origin}/contact/): Get in touch with the Green Irony team.`,
+  );
+  lines.push("");
+
+  // Optional / Reference
+  lines.push("## Optional");
+  lines.push("");
+  lines.push(
+    `- [XML Sitemap](${origin}/sitemap.xml): Full machine-readable URL list.`,
+  );
+  lines.push(
+    `- [Insights Index](${origin}/insights/): Browse all blog posts and articles.`,
+  );
+  lines.push(
+    `- [Customer Stories Index](${origin}/customer-stories/): Browse all customer success stories.`,
+  );
+  lines.push("");
+
+  const body = lines.join("\n");
+
+  res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=600, s-maxage=600, stale-while-revalidate=3600",
+  );
   res.write(body);
   res.end();
   return { props: {} };
 }
-
-

--- a/pages/robots.txt.js
+++ b/pages/robots.txt.js
@@ -1,33 +1,63 @@
-export default function RobotsTxt() { return null; }
+export default function RobotsTxt() {
+  return null;
+}
 
 export async function getServerSideProps({ req, res }) {
-  const envBase = process.env.NEXT_PUBLIC_SITE_URL || '';
-  const host = req?.headers?.host || '';
-  const proto = (req?.headers?.['x-forwarded-proto'] || 'https');
-  const origin = envBase || (host ? `${proto}://${host}` : '');
-  const sitemapUrl = origin ? `${origin.replace(/\/$/, '')}/sitemap.xml` : '/sitemap.xml';
+  const envBase = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const host = req?.headers?.host || "";
+  const proto = req?.headers?.["x-forwarded-proto"] || "https";
+  const origin =
+    envBase || (host ? `${proto}://${host}` : "") || "https://greenirony.com";
+  const sitemapUrl = `${origin.replace(/\/$/, "")}/sitemap.xml`;
 
-  const lines = [
-    // Global directives
-    'User-agent: *',
-    'Allow: /',
-    '',
-    // AI crawlers group (explicit grouping and spacing)
-    '# Friendly to AI crawlers (AEO)',
-    'User-agent: GPTBot',
-    'User-agent: ChatGPT-User',
-    'User-agent: Google-Extended',
-    'User-agent: CCBot',
-    'Allow: /',
-    '',
-    `Sitemap: ${sitemapUrl}`,
-    '',
-  ].join('\n');
+  // AI crawlers we want to allow. Listed individually so each gets its
+  // own group (some crawlers only honor directives in their own block).
+  const aiCrawlers = [
+    "GPTBot", // OpenAI training crawler
+    "ChatGPT-User", // OpenAI grounded-search user-agent
+    "OAI-SearchBot", // OpenAI search index
+    "ClaudeBot", // Anthropic crawler
+    "anthropic-ai", // Older Anthropic name (kept for back-compat)
+    "Claude-Web", // Anthropic grounded-search user-agent
+    "Google-Extended", // Google's AI training opt-in user-agent
+    "PerplexityBot", // Perplexity crawler
+    "Perplexity-User", // Perplexity grounded-search user-agent
+    "Amazonbot", // Amazon (Alexa, AI training)
+    "Applebot-Extended", // Apple's AI training opt-in
+    "cohere-ai", // Cohere
+    "Bytespider", // ByteDance / TikTok
+    "CCBot", // Common Crawl
+    "Diffbot", // Diffbot
+    "FacebookBot", // Meta link expansion
+    "ImagesiftBot", // Image-focused AI crawler
+    "Meta-ExternalAgent", // Meta AI training
+  ];
 
-  res.setHeader('Content-Type', 'text/plain');
-  res.write(lines);
+  const lines = [];
+  // Default group — allow everything
+  lines.push("User-agent: *");
+  lines.push("Allow: /");
+  lines.push("");
+
+  // Per-bot groups for explicit AI-crawler allow.
+  // Each crawler gets its own block to maximize compatibility with parsers
+  // that don't support multiple User-agent lines per group.
+  lines.push("# AI crawlers — explicitly allowed (AEO/AIO)");
+  for (const ua of aiCrawlers) {
+    lines.push(`User-agent: ${ua}`);
+    lines.push("Allow: /");
+    lines.push("");
+  }
+
+  lines.push(`Sitemap: ${sitemapUrl}`);
+  lines.push("");
+
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+  );
+  res.write(lines.join("\n"));
   res.end();
   return { props: {} };
 }
-
-

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,102 +1,144 @@
 import { getWpUrl } from "@faustwp/core";
 import { loadAllStories } from "../lib/customerStories";
 
-export default function Sitemap() { return null; }
+export default function Sitemap() {
+  return null;
+}
 
 export async function getServerSideProps(ctx) {
   // Determine base URL
   const envUrl = process.env.NEXT_PUBLIC_SITE_URL;
   let base = envUrl;
   if (!base) {
-    const proto = (ctx?.req?.headers?.["x-forwarded-proto"]) || "https";
-    const host = (ctx?.req?.headers?.["x-forwarded-host"]) || (ctx?.req?.headers?.host);
+    const proto = ctx?.req?.headers?.["x-forwarded-proto"] || "https";
+    const host =
+      ctx?.req?.headers?.["x-forwarded-host"] || ctx?.req?.headers?.host;
     if (host) base = `${proto}://${host}`;
   }
-  base = (base || '').replace(/\/$/, '');
+  base = (base || "https://greenirony.com").replace(/\/$/, "");
 
   // Collect static routes
   const staticPaths = [
-    '/',
-    // Top-level pages
-    '/about/', '/careers/', '/contact/', '/customer-stories/', '/insights/',
-    // Services index + leaf pages
-    '/services/agentforce/', '/services/mulesoft/', '/services/salesforce/', '/services/data/',
-    // Marketing landing pages
-    '/agentforce-job-description/',
-    '/ai-grant-management-guide-for-higher-education/',
-    '/grant-agent/',
-    '/grant-agent-demo-video/',
-    '/mulesoft-reviver/',
-    // Thank-you pages
-    '/thank-you-grant-agent-demo-video/',
-    '/thank-you-grant-agent-higher-ed-guide/',
-    '/thank-you-mulesoft-reviver/',
-    '/thanks/',
+    "/",
+    "/about/",
+    "/careers/",
+    "/contact/",
+    "/customer-stories/",
+    "/insights/",
+    "/services/agentforce/",
+    "/services/mulesoft/",
+    "/services/salesforce/",
+    "/services/data/",
+    "/agentforce-job-description/",
+    "/ai-grant-management-guide-for-higher-education/",
+    "/grant-agent/",
+    "/grant-agent-demo-video/",
+    "/mulesoft-reviver/",
+    "/thank-you-grant-agent-demo-video/",
+    "/thank-you-grant-agent-higher-ed-guide/",
+    "/thank-you-mulesoft-reviver/",
+    "/thanks/",
   ];
 
-  // Collect customer story routes
-  let storyPaths = [];
+  // Collect customer story routes (with datePublished as lastmod)
+  let storyEntries = [];
   try {
-    const stories = loadAllStories();
-    storyPaths = (stories || []).map((s) => `/customer-stories/${s.slug}/`);
-  } catch {}
+    const stories = loadAllStories() || [];
+    storyEntries = stories.map((s) => ({
+      loc: `/customer-stories/${s.slug}/`,
+      lastmod: s.datePublished || undefined,
+    }));
+  } catch (err) {
+    console.error("[sitemap] failed to load customer stories:", err);
+  }
 
   // Collect WordPress posts/pages via WPGraphQL
   const wpUrl = getWpUrl();
-  const graphqlEndpoint = `${wpUrl.replace(/\/$/, '')}/graphql`;
+  const graphqlEndpoint = `${wpUrl.replace(/\/$/, "")}/graphql`;
   let wpPaths = [];
   try {
     const query = `query Sitemap {
       posts(first: 500, where: { status: PUBLISH, orderby: { field: DATE, order: DESC } }) {
-        nodes { uri modifiedGmt date }
+        nodes { uri slug status modifiedGmt date }
       }
       pages(first: 500, where: { status: PUBLISH, orderby: { field: DATE, order: DESC } }) {
-        nodes { uri modifiedGmt date }
+        nodes { uri slug status modifiedGmt date }
       }
     }`;
     const resp = await fetch(graphqlEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query }),
     });
     if (resp.ok) {
       const data = await resp.json();
       const posts = data?.data?.posts?.nodes || [];
       const pages = data?.data?.pages?.nodes || [];
-      wpPaths = [...posts, ...pages].map((n) => ({
-        loc: n?.uri?.startsWith('/') ? n.uri : `/${n?.uri || ''}`,
-        lastmod: (n?.modifiedGmt || n?.date || '').split('T')[0] || undefined,
-      }));
+      wpPaths = [...posts, ...pages]
+        .filter((n) => {
+          if (!n?.uri) return false;
+          // Skip trashed posts (slug or uri may carry `__trashed` suffix)
+          if (/__trashed/i.test(n.uri) || /__trashed/i.test(n.slug || ""))
+            return false;
+          // Defensive: only keep PUBLISH status
+          if (n.status && n.status !== "publish") return false;
+          return true;
+        })
+        .map((n) => ({
+          loc: n.uri.startsWith("/") ? n.uri : `/${n.uri}`,
+          lastmod: (n.modifiedGmt || n.date || "").split("T")[0] || undefined,
+        }));
+    } else {
+      console.error("[sitemap] WPGraphQL non-OK response:", resp.status);
     }
-  } catch {}
+  } catch (err) {
+    console.error("[sitemap] WPGraphQL fetch failed:", err);
+  }
 
-  // Merge all URLs (ensure uniqueness by loc)
+  // Merge all URLs (uniqueness by loc; prefer entries with lastmod)
   const urlMap = new Map();
   const addLoc = (loc, lastmod) => {
     if (!loc) return;
-    const norm = loc.endsWith('/') ? loc : `${loc}/`;
-    if (!urlMap.has(norm)) urlMap.set(norm, lastmod);
+    const norm = loc.endsWith("/") ? loc : `${loc}/`;
+    const existing = urlMap.get(norm);
+    // Set if missing or upgrade undefined → defined
+    if (!existing || (!existing.lastmod && lastmod)) {
+      urlMap.set(norm, { lastmod });
+    }
   };
   staticPaths.forEach((p) => addLoc(p));
-  storyPaths.forEach((p) => addLoc(p));
+  storyEntries.forEach((e) => addLoc(e.loc, e.lastmod));
   wpPaths.forEach((n) => addLoc(n.loc, n.lastmod));
 
-  const urls = Array.from(urlMap.entries()).map(([loc, lastmod]) => ({ loc: `${base}${loc}`, lastmod }));
+  const urls = Array.from(urlMap.entries()).map(([loc, { lastmod }]) => ({
+    loc: `${base}${loc}`,
+    lastmod,
+  }));
 
   // Build XML
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
     `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    urls.map((u) => {
-      return [
-        '  <url>',
-        `    <loc>${u.loc}</loc>`,
-        u.lastmod ? `    <lastmod>${u.lastmod}</lastmod>` : '',
-        '  </url>'
-      ].filter(Boolean).join('\n');
-    }).join('\n') +
+    urls
+      .map((u) =>
+        [
+          "  <url>",
+          `    <loc>${u.loc}</loc>`,
+          u.lastmod ? `    <lastmod>${u.lastmod}</lastmod>` : "",
+          "  </url>",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      )
+      .join("\n") +
     `\n</urlset>`;
 
-  ctx.res.setHeader('Content-Type', 'application/xml');
+  ctx.res.setHeader("Content-Type", "application/xml; charset=utf-8");
+  // Cache at the edge for 10 minutes; serve stale up to an hour while revalidating.
+  ctx.res.setHeader(
+    "Cache-Control",
+    "public, max-age=600, s-maxage=600, stale-while-revalidate=3600",
+  );
   ctx.res.write(xml);
   ctx.res.end();
   return { props: {} };

--- a/wp-templates/single.js
+++ b/wp-templates/single.js
@@ -21,9 +21,26 @@ const POST_QUERY = gql`
       title
       content
       date
-      featuredImage { node { sourceUrl altText } }
-      categories { nodes { name slug databaseId id } }
-      tags { nodes { name slug } }
+      featuredImage {
+        node {
+          sourceUrl
+          altText
+        }
+      }
+      categories {
+        nodes {
+          name
+          slug
+          databaseId
+          id
+        }
+      }
+      tags {
+        nodes {
+          name
+          slug
+        }
+      }
       author {
         node {
           name
@@ -36,8 +53,18 @@ const POST_QUERY = gql`
 const RELATED_POSTS_QUERY = gql`
   ${POST_LIST_FRAGMENT}
   query RelatedPosts($first: Int!, $categoryIn: [ID], $notIn: [ID]) {
-    posts(first: $first, where: { categoryIn: $categoryIn, notIn: $notIn, status: PUBLISH, orderby: { field: DATE, order: DESC } }) {
-      nodes { ...PostListFragment }
+    posts(
+      first: $first
+      where: {
+        categoryIn: $categoryIn
+        notIn: $notIn
+        status: PUBLISH
+        orderby: { field: DATE, order: DESC }
+      }
+    ) {
+      nodes {
+        ...PostListFragment
+      }
     }
   }
 `;
@@ -57,52 +84,77 @@ export default function Component(props) {
     nodes: [],
   };
   const { title: siteTitle, description: siteDescription } = siteData;
-  const { title, content, date, author, featuredImage, categories, tags } = contentQuery?.post || {};
+  const { title, content, date, author, featuredImage, categories, tags } =
+    contentQuery?.post || {};
   const router = useRouter();
-  const canonicalUrl = buildCanonicalUrl(router?.asPath || '/');
+  const canonicalUrl = buildCanonicalUrl(router?.asPath || "/");
 
   // Reading time estimation (~200 wpm)
-  const plainText = typeof content === 'string' ? content.replace(/<[^>]+>/g, ' ') : '';
+  const plainText =
+    typeof content === "string" ? content.replace(/<[^>]+>/g, " ") : "";
   const wordCount = plainText.trim().split(/\s+/).filter(Boolean).length;
   const readingMinutes = Math.max(1, Math.round(wordCount / 200));
-  const description = plainText.replace(/\s+/g, ' ').trim().slice(0, 160);
+  const rawDescription = plainText.replace(/\s+/g, " ").trim();
+  const description =
+    rawDescription.length > 160
+      ? rawDescription
+          .slice(0, 157)
+          .replace(/\s+\S*$/, "")
+          .replace(/[,;:.!?\s]+$/, "") + "…"
+      : rawDescription;
 
   // Build a simple table of contents: h2/h3 ids and text
   function buildTocAndInjectIds(html) {
     let index = 0;
     const items = [];
-    const newHtml = (html || '').replace(/<h([23])(\b[^>]*)>([\s\S]*?)<\/h\1>/gi, (match, level, attrs = '', inner) => {
-      const text = inner.replace(/<[^>]+>/g, '').trim();
-      const idMatch = attrs.match(/id=["']([^"']+)["']/i);
-      let id = idMatch ? idMatch[1] : '';
-      if (!id) {
-        const base = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)+/g, '');
-        id = `${base || 'section'}-${index++}`;
-        attrs = `${attrs} id="${id}"`;
-      }
-      items.push({ id, text });
-      return `<h${level}${attrs}>${inner}</h${level}>`;
-    });
+    const newHtml = (html || "").replace(
+      /<h([23])(\b[^>]*)>([\s\S]*?)<\/h\1>/gi,
+      (match, level, attrs = "", inner) => {
+        const text = inner.replace(/<[^>]+>/g, "").trim();
+        const idMatch = attrs.match(/id=["']([^"']+)["']/i);
+        let id = idMatch ? idMatch[1] : "";
+        if (!id) {
+          const base = text
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/(^-|-$)+/g, "");
+          id = `${base || "section"}-${index++}`;
+          attrs = `${attrs} id="${id}"`;
+        }
+        items.push({ id, text });
+        return `<h${level}${attrs}>${inner}</h${level}>`;
+      },
+    );
     return { html: newHtml, toc: items };
   }
-  const { html: contentWithIds, toc } = buildTocAndInjectIds(content || '');
+  const { html: contentWithIds, toc } = buildTocAndInjectIds(content || "");
 
   // Related posts fetch (same first category, exclude current)
   const primaryCategoryId = categories?.nodes?.[0]?.databaseId;
   const excludeId = contentQuery?.post?.databaseId;
   const { data: relatedData } = useQuery(RELATED_POSTS_QUERY, {
     skip: !primaryCategoryId,
-    variables: { first: 3, categoryIn: primaryCategoryId ? [primaryCategoryId] : [], notIn: excludeId ? [excludeId] : [] },
+    variables: {
+      first: 3,
+      categoryIn: primaryCategoryId ? [primaryCategoryId] : [],
+      notIn: excludeId ? [excludeId] : [],
+    },
   });
-  const relatedPosts = (relatedData?.posts?.nodes || []).filter(p => p?.databaseId !== excludeId).slice(0,3);
+  const relatedPosts = (relatedData?.posts?.nodes || [])
+    .filter((p) => p?.databaseId !== excludeId)
+    .slice(0, 3);
 
   return (
     <>
       <Head>
-        <title>{generateSeoTitle(title || '', siteTitle || 'Green Irony')}</title>
+        <title>
+          {generateSeoTitle(title || "", siteTitle || "Green Irony")}
+        </title>
         <meta name="description" content={description} />
         {canonicalUrl ? <link rel="canonical" href={canonicalUrl} /> : null}
-        {canonicalUrl ? <meta property="og:url" content={canonicalUrl} /> : null}
+        {canonicalUrl ? (
+          <meta property="og:url" content={canonicalUrl} />
+        ) : null}
         {/* JSON-LD BlogPosting schema */}
         <script
           type="application/ld+json"
@@ -114,35 +166,90 @@ export default function Component(props) {
               headline: title,
               datePublished: date,
               dateModified: date,
-              author: author?.node?.name ? { "@type": "Person", name: author.node.name } : undefined,
+              author: author?.node?.name
+                ? { "@type": "Person", name: author.node.name }
+                : undefined,
               image: featuredImage?.node?.sourceUrl || undefined,
               description: description || undefined,
               articleSection: categories?.nodes?.[0]?.name || undefined,
               publisher: {
                 "@type": "Organization",
-                name: siteTitle || 'Green Irony',
+                name: siteTitle || "Green Irony",
                 logo: {
                   "@type": "ImageObject",
-                  url: toAbsoluteUrl('/logos/green-irony/Green-Irony-Logo.svg') || undefined,
+                  url:
+                    toAbsoluteUrl("/logos/green-irony/Green-Irony-Logo.svg") ||
+                    undefined,
                 },
               },
-              mainEntityOfPage: canonicalUrl ? { "@type": "WebPage", "@id": canonicalUrl } : undefined,
+              mainEntityOfPage: canonicalUrl
+                ? { "@type": "WebPage", "@id": canonicalUrl }
+                : undefined,
+            }),
+          }}
+        />
+        {/* JSON-LD BreadcrumbList schema */}
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  name: "Home",
+                  item: toAbsoluteUrl("/") || undefined,
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  name: "Insights",
+                  item: toAbsoluteUrl("/insights/") || undefined,
+                },
+                {
+                  "@type": "ListItem",
+                  position: 3,
+                  name: title,
+                  item: canonicalUrl || undefined,
+                },
+              ],
             }),
           }}
         />
         {/* Open Graph / Twitter */}
-        <meta property="og:type" content="article" />
-        {categories?.nodes?.[0]?.name ? <meta property="article:section" content={categories.nodes[0].name} /> : null}
-        {date ? <meta property="article:published_time" content={date} /> : null}
+        <meta property="og:type" content="article" key="og:type" />
+        {categories?.nodes?.[0]?.name ? (
+          <meta property="article:section" content={categories.nodes[0].name} />
+        ) : null}
+        {date ? (
+          <meta property="article:published_time" content={date} />
+        ) : null}
         {date ? <meta property="article:modified_time" content={date} /> : null}
-        {author?.node?.name ? <meta property="article:author" content={author.node.name} /> : null}
+        {author?.node?.name ? (
+          <meta property="article:author" content={author.node.name} />
+        ) : null}
         <meta property="og:title" content={title} />
-        {description ? <meta property="og:description" content={description} /> : null}
-        {featuredImage?.node?.sourceUrl ? <meta property="og:image" content={featuredImage.node.sourceUrl} /> : null}
-        <meta name="twitter:card" content="summary_large_image" />
+        {description ? (
+          <meta property="og:description" content={description} />
+        ) : null}
+        {featuredImage?.node?.sourceUrl ? (
+          <meta property="og:image" content={featuredImage.node.sourceUrl} />
+        ) : null}
+        <meta
+          name="twitter:card"
+          content="summary_large_image"
+          key="twitter:card"
+        />
         <meta name="twitter:title" content={title} />
-        {description ? <meta name="twitter:description" content={description} /> : null}
-        {featuredImage?.node?.sourceUrl ? <meta name="twitter:image" content={featuredImage.node.sourceUrl} /> : null}
+        {description ? (
+          <meta name="twitter:description" content={description} />
+        ) : null}
+        {featuredImage?.node?.sourceUrl ? (
+          <meta name="twitter:image" content={featuredImage.node.sourceUrl} />
+        ) : null}
       </Head>
 
       <Header
@@ -156,8 +263,14 @@ export default function Component(props) {
           title={title}
           date={date}
           author={author?.node?.name}
-          featuredImage={{ src: featuredImage?.node?.sourceUrl, alt: featuredImage?.node?.altText }}
-          categories={(categories?.nodes || []).map((c) => ({ name: c.name, slug: c.slug }))}
+          featuredImage={{
+            src: featuredImage?.node?.sourceUrl,
+            alt: featuredImage?.node?.altText,
+          }}
+          categories={(categories?.nodes || []).map((c) => ({
+            name: c.name,
+            slug: c.slug,
+          }))}
           readingMinutes={readingMinutes}
         />
         <ArticleBody html={contentWithIds} tableOfContents={toc} />
@@ -165,24 +278,42 @@ export default function Component(props) {
         {relatedPosts.length > 0 ? (
           <section className="mx-auto max-w-7xl px-6 py-12">
             <div className="mx-auto mb-6 h-px w-16 bg-gi-line" />
-            <h3 className="text-2xl font-semibold text-gi-text">Related posts</h3>
-            <div className={
-              `mt-6 grid gap-6 ` +
-              (relatedPosts.length === 1 ? 'grid-cols-1 sm:grid-cols-1 lg:grid-cols-1' :
-               relatedPosts.length === 2 ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-2' :
-               'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3')
-            }>
+            <h3 className="text-2xl font-semibold text-gi-text">
+              Related posts
+            </h3>
+            <div
+              className={
+                `mt-6 grid gap-6 ` +
+                (relatedPosts.length === 1
+                  ? "grid-cols-1 sm:grid-cols-1 lg:grid-cols-1"
+                  : relatedPosts.length === 2
+                    ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-2"
+                    : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3")
+              }
+            >
               {relatedPosts.map((p) => (
                 <PostTile key={p.id} post={p} />
               ))}
             </div>
             {categories?.nodes?.[0]?.slug ? (
-              <div className="mt-6"><Link className="btn-secondary" href={`/category/${categories.nodes[0].slug}/`}>Browse more from {categories.nodes[0].name}</Link></div>
+              <div className="mt-6">
+                <Link
+                  className="btn-secondary"
+                  href={`/category/${categories.nodes[0].slug}/`}
+                >
+                  Browse more from {categories.nodes[0].name}
+                </Link>
+              </div>
             ) : null}
           </section>
         ) : null}
 
-        <ArticleFooter tags={(tags?.nodes || []).map((t) => ({ name: t.name, slug: t.slug }))} />
+        <ArticleFooter
+          tags={(tags?.nodes || []).map((t) => ({
+            name: t.name,
+            slug: t.slug,
+          }))}
+        />
       </main>
 
       <Footer />


### PR DESCRIPTION
## Summary

Closes a set of SEO/AEO gaps that were causing slow indexing and weak answer-engine visibility on greenirony.com. Four logical commits, each scoped to one area:

- **Per-page SEO** ([8e18206](../../commit/8e18206)) — Canonical URL, hreflang, og:type dedup, BreadcrumbList JSON-LD, hand-friendly meta description truncation. The canonical/hreflang fix addresses a silent regression where `NEXT_PUBLIC_SITE_URL` being unset in production was dropping both tags entirely; a production fallback in `getBaseUrl()` makes them resilient.
- **Site-wide discovery** ([6f5543e](../../commit/6f5543e)) — Filters trashed posts out of the sitemap, adds customer-story `lastmod`, caches both for 10 min. Replaces the `/llms.txt` content (which was a robots.txt clone — not the actual spec) with a proper [llms.txt](https://llmstxt.org) markdown content map of services, customer stories, recent posts, and reference links. Adds ClaudeBot, PerplexityBot, OAI-SearchBot, and ~10 other AI crawlers to robots.txt.
- **Server-render blog listings** ([5991543](../../commit/5991543)) — `/insights/` was using Faust's `getNextStaticProps` which only honors a single `Page.query`, so the post-list queries ran client-side and the SSR HTML showed a skeleton with zero `/blog/` URLs. Replaced with a direct `apolloClient.query()` prefetch + `addApolloState` so the cache is populated server-side. Lazy-init React state from the prefetched cache so the first render contains real tiles.
- **Render all posts on /insights/** ([96aaa36](../../commit/96aaa36)) — Bumped initial fetch from `first: 9` to `first: 500` so every blog URL appears in the SSR HTML. Image bytes are still deferred via `next/image` lazy loading.

## Verified

- View-source on every blog post URL has: title, meta description, canonical, hreflang, OG (article-type), Twitter card, BlogPosting + BreadcrumbList JSON-LD.
- `/sitemap.xml` returns no trashed URLs, includes customer-story dates, sets a 10-min `Cache-Control`.
- `/llms.txt` returns proper markdown with curated link sections.
- `/robots.txt` allows ClaudeBot, PerplexityBot, OAI-SearchBot, etc.
- `/insights/` SSR HTML contains 43 unique `/blog/` post links (was 0) and an `ItemList` JSON-LD block.
- `pnpm build` and `pnpm tsc --noEmit` clean.

## Test plan

- [ ] Hit a blog post URL in production after deploy; `curl -sL <url> | grep -E '(canonical|BreadcrumbList|"@type":"BlogPosting"|hreflang)'` returns hits for all four.
- [ ] `curl -sL https://greenirony.com/sitemap.xml | grep -c '__trashed'` returns 0.
- [ ] `curl -sL https://greenirony.com/llms.txt` shows H1 + `## Services` + `## Customer Stories` + `## Insights` markdown sections.
- [ ] `curl -sL https://greenirony.com/insights/ | grep -oE 'href="[^"]*/blog/[a-z0-9-]+/' | sort -u | wc -l` shows the full count of published posts (~25+), not 9.
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) passes for one blog post and one customer story.
- [ ] Lighthouse SEO ≥ 90 on a representative blog post.
- [ ] Re-submit `sitemap.xml` in Google Search Console and request indexing for the most recent blog posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)